### PR TITLE
Slick-Renderer: Fixing font handling

### DIFF
--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/font/loader/HieroUnicodeSlickRenderFontLoader.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/font/loader/HieroUnicodeSlickRenderFontLoader.java
@@ -32,8 +32,11 @@ public final class HieroUnicodeSlickRenderFontLoader extends AbstractJavaSlickRe
       if (javaFont == null) {
         throw new SlickLoadFontException("Loading TTF Font failed.");
       }
+      
+      final UnicodeFont uniFont = new UnicodeFont(javaFont, hieroSettings);
+      uniFont.addAsciiGlyphs();
 
-      return new UnicodeSlickRenderFont(new UnicodeFont(javaFont, hieroSettings), javaFont);
+      return new UnicodeSlickRenderFont(uniFont, javaFont);
     } catch (final SlickException e) {
       throw new SlickLoadFontException("Loading the font failed.", e);
     } catch (final RuntimeException e) {

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/font/loader/UnicodeSlickRenderFontLoader.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/font/loader/UnicodeSlickRenderFontLoader.java
@@ -26,10 +26,14 @@ public final class UnicodeSlickRenderFontLoader extends AbstractJavaSlickRenderF
   @SuppressWarnings("unchecked")
   public SlickRenderFont loadFont(final Graphics g, final String filename) throws SlickLoadFontException {
     try {
-      final Font javaFont = loadJavaFont(filename);
+      Font javaFont = loadJavaFont(filename);
 
       if (javaFont == null) {
         throw new SlickLoadFontException("Loading TTF Font failed.");
+      }
+      
+      if (javaFont.getSize() == 1) {
+        javaFont = javaFont.deriveFont(12.f);
       }
 
       final UnicodeFont uniFont = new UnicodeFont(javaFont);


### PR DESCRIPTION
Title says all. Its not a nice way to fix the sizing problem. But as default implementation it will do the job.

Sadly Nifty does not request the size of a font when loading it... would be handy for fonts that get scaled freely, such as TTF fonts.
