### PR TITLE
ColorValidator - Bugfix

### DIFF
--- a/nifty-core/src/main/java/de/lessvoid/nifty/loaderv2/types/helper/OnClickType.java
+++ b/nifty-core/src/main/java/de/lessvoid/nifty/loaderv2/types/helper/OnClickType.java
@@ -9,7 +9,7 @@ public class OnClickType {
   /**
    * The pattern used to check
    */
-  private static final Pattern VALID_PATTERN = Pattern.compile("\\w+\\((?|\\w+(?,\\s*\\w+)*)\\)");
+  private static final Pattern VALID_PATTERN = Pattern.compile("\\w+\\((?:|\\w+(?:,\\s*\\w+)*)\\)");
   private String value;
 
   public OnClickType(final String valueParam) {

--- a/nifty-core/src/main/java/de/lessvoid/nifty/loaderv2/types/helper/OnClickType.java
+++ b/nifty-core/src/main/java/de/lessvoid/nifty/loaderv2/types/helper/OnClickType.java
@@ -1,9 +1,15 @@
 package de.lessvoid.nifty.loaderv2.types.helper;
 
+import java.util.regex.Pattern;
+
 import de.lessvoid.nifty.Nifty;
 import de.lessvoid.nifty.NiftyMethodInvoker;
 
 public class OnClickType {
+  /**
+   * The pattern used to check
+   */
+  private static final Pattern VALID_PATTERN = Pattern.compile("\\w+\\((?|\\w+(?,\\s*\\w+)*)\\)");
   private String value;
 
   public OnClickType(final String valueParam) {
@@ -15,7 +21,7 @@ public class OnClickType {
       return false;
     }
 
-    return value.matches("\\w+\\((|\\w+(,\\s*\\w+)*)\\)");
+    return VALID_PATTERN.matcher(value).matches();
   }
 
   public NiftyMethodInvoker getMethod(final Nifty nifty, final Object ... controlController) {

--- a/nifty-core/src/main/java/de/lessvoid/nifty/tools/ColorValidator.java
+++ b/nifty-core/src/main/java/de/lessvoid/nifty/tools/ColorValidator.java
@@ -1,37 +1,99 @@
 package de.lessvoid.nifty.tools;
 
+import java.util.regex.Pattern;
+
 /**
  * This checks a given String that represents a color for being valid. Supported
  * are both short mode "#f12f" and long mode "#ff1122ff"
+ * 
  * @author void
+ * @author Martin Karing &lt;nitram@illarion.org&gt;
  */
 public class ColorValidator {
+  /**
+   * The pattern used to check if the string is valid to be a color definition.
+   */
+  private static final Pattern colorPattern = Pattern.compile("#\\p{XDigit}{3,8}");
+
+  /**
+   * Check if a string fits any type of color definition string.
+   * 
+   * @param toCheck
+   *          the text to check
+   * @return <code>true</code> in case the text is a color definition
+   */
   public boolean isValid(final String toCheck) {
     if (toCheck == null) {
       return false;
     }
-    if (isShortMode(toCheck)) {
-      return true;
-    }
-    if (isLongMode(toCheck)) {
-      return true;
-    }
-    return false;
+
+    return colorPattern.matcher(toCheck).matches();
   }
 
+  /**
+   * Check if the color text is written in the short form with alpha. The text
+   * would have to look like this: <code>#rgba</code>
+   * 
+   * @param toCheck
+   *          the text to check
+   * @return <code>true</code> in case the text is a short form color definition
+   *         with alpha
+   */
   public boolean isShortMode(final String toCheck) {
-    return toCheck.matches("#[0-9a-fA-F]{4}");
-  }  
-
-  public boolean isShortModeWithoutAlpha(final String toCheck) {
-    return toCheck.matches("#[0-9a-fA-F]{3}");
-  }  
-
-  public boolean isLongMode(final String toCheck) {
-    return toCheck.matches("#[0-9a-fA-F]{8}");
+    return isColor(toCheck, 4);
   }
 
+  /**
+   * Check if the color text is written in the short form without alpha. The
+   * text would have to look like this: <code>#rgb</code>
+   * 
+   * @param toCheck
+   *          the text to check
+   * @return <code>true</code> in case the text is a short form color definition
+   *         without alpha
+   */
+  public boolean isShortModeWithoutAlpha(final String toCheck) {
+    return isColor(toCheck, 3);
+  }
+
+  /**
+   * Check if the color text is written in the long form with alpha. The text
+   * would have to look like this: <code>#rrggbbaa</code>
+   * 
+   * @param toCheck
+   *          the text to check
+   * @return <code>true</code> in case the text is a long form color definition
+   *         with alpha
+   */
+  public boolean isLongMode(final String toCheck) {
+    return isColor(toCheck, 8);
+  }
+
+  /**
+   * Check if the color text is written in the long form without alpha. The text
+   * would have to look like this: <code>#rrggbb</code>
+   * 
+   * @param toCheck
+   *          the text to check
+   * @return <code>true</code> in case the text is a long form color definition
+   *         without alpha
+   */
   public boolean isLongModeWithoutAlpha(final String toCheck) {
-    return toCheck.matches("#[0-9a-fA-F]{6}");
+    return isColor(toCheck, 6);
+  }
+
+  /**
+   * Test of a text contains a color definition with a specified amount of color
+   * digits.
+   * 
+   * @param toCheck
+   *          the text to check
+   * @param components
+   *          the amount of digits to be used to define the color
+   * @return <code>true</code> if the text fits a color text and meets the
+   *         required length exactly
+   */
+  private boolean isColor(final String toCheck, final int components) {
+    return (toCheck.length() == (components + 1) && isValid(toCheck));
   }
 }

--- a/nifty-core/src/main/java/de/lessvoid/nifty/tools/ColorValidator.java
+++ b/nifty-core/src/main/java/de/lessvoid/nifty/tools/ColorValidator.java
@@ -26,8 +26,14 @@ public class ColorValidator {
     if (toCheck == null) {
       return false;
     }
-
-    return colorPattern.matcher(toCheck).matches();
+    
+    final int digits = toCheck.length() - 1;
+    
+    if (digits == 3 || digits == 4 || digits == 6 || digits == 8) {
+      return checkSyntax(toCheck);
+    }
+    
+    return false;
   }
 
   /**
@@ -94,6 +100,18 @@ public class ColorValidator {
    *         required length exactly
    */
   private boolean isColor(final String toCheck, final int components) {
-    return (toCheck.length() == (components + 1) && isValid(toCheck));
+    return (toCheck != null && toCheck.length() == (components + 1) && checkSyntax(toCheck));
+  }
+
+  /**
+   * Check if the general syntax of the color string fits. That test does not
+   * validate that the string has the required length.
+   * 
+   * @param toCheck
+   *          the text to check
+   * @return <code>true</code> in case the text matches the required syntax
+   */
+  private boolean checkSyntax(final String toCheck) {
+    return colorPattern.matcher(toCheck).matches();
   }
 }

--- a/nifty-core/src/test/java/de/lessvoid/nifty/tools/ColorValidatorTest.java
+++ b/nifty-core/src/test/java/de/lessvoid/nifty/tools/ColorValidatorTest.java
@@ -8,53 +8,144 @@ import static org.junit.Assert.assertFalse;
 public class ColorValidatorTest {
   private ColorValidator validator = new ColorValidator();
 
+  private String[] shortColor = new String[] { "#000", "#fff", "#FFF", "#0af", "#0AF", "#0aF", "#0Af", "#aaa", "#157" };
+
+  private String[] shortAlphaColor = new String[] { "#0000", "#ffff", "#FFFF", "#0afb", "#0AFB", "#0aFb", "#0AfB",
+      "#aaaa", "#1579" };
+  
+  private String[] longColor = new String[] { "#000000", "#ffffff", "#FFFFFF", "#00aaff", "#00AAFF", "#00aaFF", "#00AAff", "#aaaaaa", "#115577" };
+
+  private String[] longAlphaColor = new String[] { "#00000000", "#ffffffff", "#FFFFFFFF", "#00aaffbb", "#00AAFFBB", "#00aaFFbb", "#00AAffBB",
+      "#aaaaaaaa", "#11557799" };
+
   @Test
   public void testInvalid() {
-    assertFalse(validator.isValid(null));
-    assertFalse(validator.isValid("#"));
+    testInvalid(null);
+    testInvalid("#");
+    testInvalid("#0");
+    testInvalid("#00");
+    testInvalid("#00000");
+    testInvalid("#0000000");
+    testInvalid("g#000");
+    testInvalid(" #000");
+    testInvalid("#000j");
+    testInvalid("#000 ");
+    testInvalid("#000 ");
   }
 
-  @Test
-  public void testShortModeInvalid() {
-    assertFalse(validator.isValid("#f"));
-    assertFalse(validator.isValid("#00"));
-    assertFalse(validator.isValid("#000"));    
+  private void testInvalid(final String text) {
+    assertFalse(generateInvalidColorMsg(text), validator.isValid(text));
   }
 
-  @Test
-  public void testLongModeInvalid() {
-    assertFalse(validator.isValid("#ff0000"));
+  private String generateInvalidColorMsg(final String color) {
+    final StringBuilder builder = new StringBuilder();
+    builder.append("Invalid color \"");
+    builder.append(String.valueOf(color));
+    builder.append("\" was detected as valid.");
+    return builder.toString();
   }
   
   @Test
-  public void testShortModeValid() {
-    assertTrue(validator.isValid("#f00F"));
-    assertTrue(validator.isValid("#1230"));
+  public void testValid() {
+    for (final String color : shortColor) {
+      testValid(color);
+    }
+    for (final String color : shortAlphaColor) {
+      testValid(color);
+    }
+    for (final String color : longColor) {
+      testValid(color);
+    }
+    for (final String color : longAlphaColor) {
+      testValid(color);
+    }
   }
 
-  @Test
-  public void testLongModeValid() {
-    assertTrue(validator.isValid("#ff0000FF"));
-    assertTrue(validator.isValid("#11223300"));
+  private void testValid(final String text) {
+    assertTrue(generateValidColorMsg(text), validator.isValid(text));
   }
 
-  @Test
-  public void testShortModeIncomplete() {
-    assertTrue(validator.isShortModeWithoutAlpha("#123"));
+  private String generateValidColorMsg(final String color) {
+    final StringBuilder builder = new StringBuilder();
+    builder.append("Valid color \"");
+    builder.append(String.valueOf(color));
+    builder.append("\" was detected as invalid.");
+    return builder.toString();
   }
-
+  
   @Test
-  public void testShortModeIncompleteInvalid() {
-    assertFalse(validator.isShortModeWithoutAlpha("#123F"));
+  public void testShortMode() {
+    for (final String color : shortColor) {
+      assertTrue(generateValidColorMsg(color), validator.isShortModeWithoutAlpha(color));
+    }
+
+    for (final String color : shortAlphaColor) {
+      assertFalse(generateInvalidColorMsg(color), validator.isShortModeWithoutAlpha(color));
+    }
+
+    for (final String color : longColor) {
+      assertFalse(generateInvalidColorMsg(color), validator.isShortModeWithoutAlpha(color));
+    }
+
+    for (final String color : longAlphaColor) {
+      assertFalse(generateInvalidColorMsg(color), validator.isShortModeWithoutAlpha(color));
+    }
   }
-
+  
   @Test
-  public void testLongModeIncomplete() {
-    assertTrue(validator.isLongModeWithoutAlpha("#112233"));
+  public void testShortAlphaMode() {
+    for (final String color : shortColor) {
+      assertFalse(generateInvalidColorMsg(color), validator.isShortMode(color));
+    }
+
+    for (final String color : shortAlphaColor) {
+      assertTrue(generateValidColorMsg(color), validator.isShortMode(color));
+    }
+
+    for (final String color : longColor) {
+      assertFalse(generateInvalidColorMsg(color), validator.isShortMode(color));
+    }
+
+    for (final String color : longAlphaColor) {
+      assertFalse(generateInvalidColorMsg(color), validator.isShortMode(color));
+    }
   }
-
+  
   @Test
-  public void testLongModeIncompleteInvalid() {
-    assertFalse(validator.isLongModeWithoutAlpha("#112233FF"));
+  public void testLongMode() {
+    for (final String color : shortColor) {
+      assertFalse(generateInvalidColorMsg(color), validator.isLongModeWithoutAlpha(color));
+    }
+
+    for (final String color : shortAlphaColor) {
+      assertFalse(generateInvalidColorMsg(color), validator.isLongModeWithoutAlpha(color));
+    }
+
+    for (final String color : longColor) {
+      assertTrue(generateValidColorMsg(color), validator.isLongModeWithoutAlpha(color));
+    }
+
+    for (final String color : longAlphaColor) {
+      assertFalse(generateInvalidColorMsg(color), validator.isLongModeWithoutAlpha(color));
+    }
+  }
+  
+  @Test
+  public void testLongAlphaMode() {
+    for (final String color : shortColor) {
+      assertFalse(generateInvalidColorMsg(color), validator.isLongMode(color));
+    }
+
+    for (final String color : shortAlphaColor) {
+      assertFalse(generateInvalidColorMsg(color), validator.isLongMode(color));
+    }
+
+    for (final String color : longColor) {
+      assertFalse(generateInvalidColorMsg(color), validator.isLongMode(color));
+    }
+    
+    for (final String color : longAlphaColor) {
+      assertTrue(generateValidColorMsg(color), validator.isLongMode(color));
+    }
   }
 }

--- a/nifty-core/src/test/java/de/lessvoid/nifty/tools/ColorValidatorTest.java
+++ b/nifty-core/src/test/java/de/lessvoid/nifty/tools/ColorValidatorTest.java
@@ -12,11 +12,12 @@ public class ColorValidatorTest {
 
   private String[] shortAlphaColor = new String[] { "#0000", "#ffff", "#FFFF", "#0afb", "#0AFB", "#0aFb", "#0AfB",
       "#aaaa", "#1579" };
-  
-  private String[] longColor = new String[] { "#000000", "#ffffff", "#FFFFFF", "#00aaff", "#00AAFF", "#00aaFF", "#00AAff", "#aaaaaa", "#115577" };
 
-  private String[] longAlphaColor = new String[] { "#00000000", "#ffffffff", "#FFFFFFFF", "#00aaffbb", "#00AAFFBB", "#00aaFFbb", "#00AAffBB",
-      "#aaaaaaaa", "#11557799" };
+  private String[] longColor = new String[] { "#000000", "#ffffff", "#FFFFFF", "#00aaff", "#00AAFF", "#00aaFF",
+      "#00AAff", "#aaaaaa", "#115577" };
+
+  private String[] longAlphaColor = new String[] { "#00000000", "#ffffffff", "#FFFFFFFF", "#00aaffbb", "#00AAFFBB",
+      "#00aaFFbb", "#00AAffBB", "#aaaaaaaa", "#11557799" };
 
   @Test
   public void testInvalid() {
@@ -44,7 +45,7 @@ public class ColorValidatorTest {
     builder.append("\" was detected as valid.");
     return builder.toString();
   }
-  
+
   @Test
   public void testValid() {
     for (final String color : shortColor) {
@@ -72,7 +73,7 @@ public class ColorValidatorTest {
     builder.append("\" was detected as invalid.");
     return builder.toString();
   }
-  
+
   @Test
   public void testShortMode() {
     for (final String color : shortColor) {
@@ -91,7 +92,7 @@ public class ColorValidatorTest {
       assertFalse(generateInvalidColorMsg(color), validator.isShortModeWithoutAlpha(color));
     }
   }
-  
+
   @Test
   public void testShortAlphaMode() {
     for (final String color : shortColor) {
@@ -110,7 +111,7 @@ public class ColorValidatorTest {
       assertFalse(generateInvalidColorMsg(color), validator.isShortMode(color));
     }
   }
-  
+
   @Test
   public void testLongMode() {
     for (final String color : shortColor) {
@@ -129,7 +130,7 @@ public class ColorValidatorTest {
       assertFalse(generateInvalidColorMsg(color), validator.isLongModeWithoutAlpha(color));
     }
   }
-  
+
   @Test
   public void testLongAlphaMode() {
     for (final String color : shortColor) {
@@ -143,7 +144,7 @@ public class ColorValidatorTest {
     for (final String color : longColor) {
       assertFalse(generateInvalidColorMsg(color), validator.isLongMode(color));
     }
-    
+
     for (final String color : longAlphaColor) {
       assertTrue(generateValidColorMsg(color), validator.isLongMode(color));
     }


### PR DESCRIPTION
Fixed some bugs in the color validator that were shadowed by the unit test (that contained just the same bug)
Improved the usage of the regular expression for detecting valid and invalid color definition strings.

The problem was that the color validator did not properly detect the versions without alpha component at the valid test. Also the use of String.matches along with static pattern made this function very inefficient.
