### PR TITLE
Slick-Renderer Updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /.project
 /.settings
 .DS_Store
+*.iml
+/.idea

--- a/nifty-renderer-slick/pom.xml
+++ b/nifty-renderer-slick/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>lessvoid</groupId>

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/NiftyBasicGame.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/NiftyBasicGame.java
@@ -5,9 +5,10 @@ import org.newdawn.slick.Graphics;
 import org.newdawn.slick.SlickException;
 
 /**
- * This "game" implements all the features of a Slick BasicGame with the sole
- * purpose of displaying a NiftyGUI on top of it.
- * 
+ * This "game" implements all the features of a Slick BasicGame with the sole purpose of displaying a NiftyGUI on top
+ * of
+ * it.
+ *
  * @author Martin Karing &lt;nitram@illarion.org&gt;
  */
 public abstract class NiftyBasicGame extends NiftyOverlayBasicGame {
@@ -18,26 +19,21 @@ public abstract class NiftyBasicGame extends NiftyOverlayBasicGame {
   private final String startScreen;
 
   /**
-   * Create a new game that displays the Nifty GUI and set the title that is
-   * shown.
-   * 
-   * @param gameTitle
-   *          the title of the game
+   * Create a new game that displays the Nifty GUI and set the title that is shown.
+   *
+   * @param gameTitle the title of the game
    */
-  public NiftyBasicGame(final String gameTitle) {
+  protected NiftyBasicGame(final String gameTitle) {
     this(gameTitle, "start");
   }
 
   /**
-   * Create a new game that displays the Nifty GUI and set the title and the
-   * start screen for this game.
-   * 
-   * @param gameTitle
-   *          the title of the game
-   * @param niftyStartScreen
-   *          the name of the screen that should be called first
+   * Create a new game that displays the Nifty GUI and set the title and the start screen for this game.
+   *
+   * @param gameTitle the title of the game
+   * @param niftyStartScreen the name of the screen that should be called first
    */
-  public NiftyBasicGame(final String gameTitle, final String niftyStartScreen) {
+  protected NiftyBasicGame(final String gameTitle, final String niftyStartScreen) {
     super(gameTitle);
     startScreen = niftyStartScreen;
   }
@@ -46,14 +42,13 @@ public abstract class NiftyBasicGame extends NiftyOverlayBasicGame {
    * When initializing the game its only needed to prepare the GUI for display.
    */
   @Override
-  protected final void initGameAndGUI(final GameContainer container) throws SlickException {
+  protected final void initGameAndGUI(final GameContainer container) {
     initNifty(container);
     getNifty().gotoScreen(startScreen);
   }
 
   /**
-   * Rendering the GUI only requires that the display is cleared before
-   * rendering the screen.
+   * Rendering the GUI only requires that the display is cleared before rendering the screen.
    */
   @Override
   protected void renderGame(final GameContainer container, final Graphics g) throws SlickException {
@@ -61,8 +56,7 @@ public abstract class NiftyBasicGame extends NiftyOverlayBasicGame {
   }
 
   /**
-   * Updating the game is not needed in this implementation as only the GUI is
-   * displayed.
+   * Updating the game is not needed in this implementation as only the GUI is displayed.
    */
   @Override
   protected void updateGame(final GameContainer container, final int delta) throws SlickException {

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/NiftyBasicGameState.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/NiftyBasicGameState.java
@@ -1,11 +1,10 @@
 package de.lessvoid.nifty.slick2d;
 
+import de.lessvoid.nifty.slick2d.input.PlainSlickInputSystem;
 import org.newdawn.slick.GameContainer;
 import org.newdawn.slick.Graphics;
 import org.newdawn.slick.SlickException;
 import org.newdawn.slick.state.StateBasedGame;
-
-import de.lessvoid.nifty.slick2d.input.PlainSlickInputSystem;
 
 public abstract class NiftyBasicGameState extends NiftyOverlayBasicGameState {
   /**
@@ -21,21 +20,18 @@ public abstract class NiftyBasicGameState extends NiftyOverlayBasicGameState {
   }
 
   /**
-   * Create this game state and set the screen that is called upon entering this
-   * state.
-   * 
-   * @param niftyStartScreen
-   *          the name of the screen Nifty is supposed to goto once the game
-   *          state is entered
+   * Create this game state and set the screen that is called upon entering this state.
+   *
+   * @param niftyStartScreen the name of the screen Nifty is supposed to goto once the game state is entered
    */
   protected NiftyBasicGameState(final String niftyStartScreen) {
-    super();
     startScreen = niftyStartScreen;
   }
 
   /**
    * Enter this game state.
    */
+  @SuppressWarnings("PublicMethodNotExposedInInterface")
   @Override
   public void enterState(final GameContainer container, final StateBasedGame game) throws SlickException {
     if (startScreen != null) {
@@ -47,7 +43,7 @@ public abstract class NiftyBasicGameState extends NiftyOverlayBasicGameState {
    * When initializing the game its only needed to prepare the GUI for display.
    */
   @Override
-  protected final void initGameAndGUI(final GameContainer container, final StateBasedGame game) throws SlickException {
+  protected final void initGameAndGUI(final GameContainer container, final StateBasedGame game) {
     initNifty(container, game, new PlainSlickInputSystem());
     getNifty().gotoScreen(startScreen);
   }
@@ -55,28 +51,26 @@ public abstract class NiftyBasicGameState extends NiftyOverlayBasicGameState {
   /**
    * Leave this game state.
    */
+  @SuppressWarnings("PublicMethodNotExposedInInterface")
   @Override
   public void leaveState(final GameContainer container, final StateBasedGame game) throws SlickException {
     // nothing
   }
 
   /**
-   * Rendering the GUI only requires that the display is cleared before
-   * rendering the screen.
+   * Rendering the GUI only requires that the display is cleared before rendering the screen.
    */
   @Override
-  protected void renderGame(final GameContainer container, final StateBasedGame game, final Graphics g)
-      throws SlickException {
+  protected void renderGame(
+      final GameContainer container, final StateBasedGame game, final Graphics g) throws SlickException {
     g.clear();
   }
 
   /**
-   * Updating the game is not needed in this implementation as only the GUI is
-   * displayed.
+   * Updating the game is not needed in this implementation as only the GUI is displayed.
    */
   @Override
-  protected final void updateGame(final GameContainer container, final StateBasedGame game, final int delta)
-      throws SlickException {
+  protected final void updateGame(final GameContainer container, final StateBasedGame game, final int delta) {
     // nothing to do
   }
 }

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/NiftyGame.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/NiftyGame.java
@@ -2,12 +2,11 @@ package de.lessvoid.nifty.slick2d;
 
 import org.newdawn.slick.GameContainer;
 import org.newdawn.slick.Graphics;
-import org.newdawn.slick.SlickException;
 
 /**
- * This "game" does nothing but showing the Nifty GUI on the screen. For real
- * games the Nifty Overlay Game should be used.
- * 
+ * This "game" does nothing but showing the Nifty GUI on the screen. For real games the Nifty Overlay Game should be
+ * used.
+ *
  * @author Martin Karing &lt;nitram@illarion.org&gt;
  */
 public abstract class NiftyGame extends NiftyOverlayGame {
@@ -22,27 +21,21 @@ public abstract class NiftyGame extends NiftyOverlayGame {
   private final String title;
 
   /**
-   * Create a new game that displays the Nifty GUI and set the title that is
-   * shown.
-   * 
-   * @param gameTitle
-   *          the title of the game
+   * Create a new game that displays the Nifty GUI and set the title that is shown.
+   *
+   * @param gameTitle the title of the game
    */
-  public NiftyGame(final String gameTitle) {
+  protected NiftyGame(final String gameTitle) {
     this(gameTitle, "start");
   }
 
   /**
-   * Create a new game that displays the Nifty GUI and set the title and the
-   * start screen for this game.
-   * 
-   * @param gameTitle
-   *          the title of the game
-   * @param niftyStartScreen
-   *          the name of the screen that should be called first
+   * Create a new game that displays the Nifty GUI and set the title and the start screen for this game.
+   *
+   * @param gameTitle the title of the game
+   * @param niftyStartScreen the name of the screen that should be called first
    */
-  public NiftyGame(final String gameTitle, final String niftyStartScreen) {
-    super();
+  protected NiftyGame(final String gameTitle, final String niftyStartScreen) {
     title = gameTitle;
     startScreen = niftyStartScreen;
   }
@@ -67,7 +60,7 @@ public abstract class NiftyGame extends NiftyOverlayGame {
    * When initializing the game its only needed to prepare the GUI for display.
    */
   @Override
-  protected final void initGameAndGUI(final GameContainer container) throws SlickException {
+  protected final void initGameAndGUI(final GameContainer container) {
     initNifty(container);
 
     if (startScreen != null) {
@@ -76,20 +69,18 @@ public abstract class NiftyGame extends NiftyOverlayGame {
   }
 
   /**
-   * Rendering the GUI only requires that the display is cleared before
-   * rendering the screen.
+   * Rendering the GUI only requires that the display is cleared before rendering the screen.
    */
   @Override
-  protected final void renderGame(final GameContainer container, final Graphics g) throws SlickException {
+  protected final void renderGame(final GameContainer container, final Graphics g) {
     g.clear();
   }
 
   /**
-   * Updating the game is not needed in this implementation as only the GUI is
-   * displayed.
+   * Updating the game is not needed in this implementation as only the GUI is displayed.
    */
   @Override
-  protected final void updateGame(final GameContainer container, final int delta) throws SlickException {
+  protected final void updateGame(final GameContainer container, final int delta) {
     // nothing to do
   }
 }

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/NiftyGameState.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/NiftyGameState.java
@@ -1,11 +1,10 @@
 package de.lessvoid.nifty.slick2d;
 
+import de.lessvoid.nifty.slick2d.input.PlainSlickInputSystem;
 import org.newdawn.slick.GameContainer;
 import org.newdawn.slick.Graphics;
 import org.newdawn.slick.SlickException;
 import org.newdawn.slick.state.StateBasedGame;
-
-import de.lessvoid.nifty.slick2d.input.PlainSlickInputSystem;
 
 public abstract class NiftyGameState extends NiftyOverlayGameState {
   /**
@@ -21,15 +20,11 @@ public abstract class NiftyGameState extends NiftyOverlayGameState {
   }
 
   /**
-   * Create this game state and set the screen that is called upon entering this
-   * state.
-   * 
-   * @param niftyStartScreen
-   *          the name of the screen Nifty is supposed to goto once the game
-   *          state is entered
+   * Create this game state and set the screen that is called upon entering this state.
+   *
+   * @param niftyStartScreen the name of the screen Nifty is supposed to goto once the game state is entered
    */
   protected NiftyGameState(final String niftyStartScreen) {
-    super();
     startScreen = niftyStartScreen;
   }
 
@@ -47,7 +42,7 @@ public abstract class NiftyGameState extends NiftyOverlayGameState {
    * When initializing the game its only needed to prepare the GUI for display.
    */
   @Override
-  protected final void initGameAndGUI(final GameContainer container, final StateBasedGame game) throws SlickException {
+  protected final void initGameAndGUI(final GameContainer container, final StateBasedGame game) {
     initNifty(container, game, new PlainSlickInputSystem());
     getNifty().gotoScreen(startScreen);
   }
@@ -61,22 +56,18 @@ public abstract class NiftyGameState extends NiftyOverlayGameState {
   }
 
   /**
-   * Rendering the GUI only requires that the display is cleared before
-   * rendering the screen.
+   * Rendering the GUI only requires that the display is cleared before rendering the screen.
    */
   @Override
-  protected final void renderGame(final GameContainer container, final StateBasedGame game, final Graphics g)
-      throws SlickException {
+  protected final void renderGame(final GameContainer container, final StateBasedGame game, final Graphics g) {
     g.clear();
   }
 
   /**
-   * Updating the game is not needed in this implementation as only the GUI is
-   * displayed.
+   * Updating the game is not needed in this implementation as only the GUI is displayed.
    */
   @Override
-  protected final void updateGame(final GameContainer container, final StateBasedGame game, final int delta)
-      throws SlickException {
+  protected final void updateGame(final GameContainer container, final StateBasedGame game, final int delta) {
     // nothing to do
   }
 }

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/NiftyInputForwarding.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/NiftyInputForwarding.java
@@ -1,0 +1,24 @@
+package de.lessvoid.nifty.slick2d;
+
+import de.lessvoid.nifty.slick2d.input.ForwardingInputSystem;
+
+/**
+ * This interface defines the methods available in the game implementations to control how input events are send to
+ * the Nifty-GUI or to the underlying game.
+ */
+public interface NiftyInputForwarding {
+  /**
+   * Check if input forwarding is supported.
+   *
+   * @return {@code true} in case input forwarding is supported
+   */
+  boolean isInputForwardingSupported();
+
+  /**
+   * Get the control class that enables changing the way how the input events are send to the Nifty-GUI and to the
+   * underlying game.
+   *
+   * @return the forwarding control instance
+   */
+  ForwardingInputSystem getInputForwardingControl();
+}

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/NiftyInputForwarding.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/NiftyInputForwarding.java
@@ -3,17 +3,10 @@ package de.lessvoid.nifty.slick2d;
 import de.lessvoid.nifty.slick2d.input.ForwardingInputSystem;
 
 /**
- * This interface defines the methods available in the game implementations to control how input events are send to
- * the Nifty-GUI or to the underlying game.
+ * This interface defines the methods available in the game implementations to control how input events are send to the
+ * Nifty-GUI or to the underlying game.
  */
 public interface NiftyInputForwarding {
-  /**
-   * Check if input forwarding is supported.
-   *
-   * @return {@code true} in case input forwarding is supported
-   */
-  boolean isInputForwardingSupported();
-
   /**
    * Get the control class that enables changing the way how the input events are send to the Nifty-GUI and to the
    * underlying game.
@@ -21,4 +14,10 @@ public interface NiftyInputForwarding {
    * @return the forwarding control instance
    */
   ForwardingInputSystem getInputForwardingControl();
+  /**
+   * Check if input forwarding is supported.
+   *
+   * @return {@code true} in case input forwarding is supported
+   */
+  boolean isInputForwardingSupported();
 }

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/NiftyOrderControl.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/NiftyOrderControl.java
@@ -1,0 +1,36 @@
+package de.lessvoid.nifty.slick2d;
+
+/**
+ * This interface defined the functions to control the order of rendering and updating the Nifty-GUI and the game.
+ *
+ * @author Martin Karing &lt;nitram@illarion.org&gt;
+ */
+public interface NiftyOrderControl {
+  /**
+   * Get the current rendering order.
+   *
+   * @return the current render order
+   */
+  NiftyRenderOrder getRenderOrder();
+
+  /**
+   * Get the current updating order.
+   *
+   * @return the current update order
+   */
+  NiftyUpdateOrder getUpdateOrder();
+
+  /**
+   * Set the rendering order that is supposed to be used.
+   *
+   * @param order the render order
+   */
+  void setRenderOrder(NiftyRenderOrder order);
+
+  /**
+   * Set the updating order that is supposed to be used.
+   *
+   * @param order the update order
+   */
+  void setUpdateOrder(NiftyUpdateOrder order);
+}

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/NiftyOverlayBasicGame.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/NiftyOverlayBasicGame.java
@@ -1,6 +1,7 @@
 package de.lessvoid.nifty.slick2d;
 
 import de.lessvoid.nifty.Nifty;
+import de.lessvoid.nifty.slick2d.input.ForwardingInputSystem;
 import de.lessvoid.nifty.slick2d.input.SlickInputSystem;
 import de.lessvoid.nifty.slick2d.input.SlickSlickInputSystem;
 import de.lessvoid.nifty.slick2d.render.SlickRenderDevice;
@@ -14,11 +15,16 @@ import org.newdawn.slick.*;
  *
  * @author Martin Karing &lt;nitram@illarion.org&gt;
  */
-public abstract class NiftyOverlayBasicGame extends BasicGame {
+public abstract class NiftyOverlayBasicGame extends BasicGame implements NiftyInputForwarding {
   /**
    * The one and only Nifty GUI.
    */
   private Nifty niftyGUI = null;
+
+  /**
+   * This variable provides the control over the forwarding implementations.
+   */
+  private ForwardingInputSystem inputForwardingControl;
 
   /**
    * Forward constructor to set the title of the game.
@@ -27,6 +33,11 @@ public abstract class NiftyOverlayBasicGame extends BasicGame {
    */
   protected NiftyOverlayBasicGame(final String title) {
     super(title);
+  }
+   
+  @Override
+  public final ForwardingInputSystem getInputForwardingControl() {
+    return inputForwardingControl;
   }
 
   /**
@@ -84,6 +95,10 @@ public abstract class NiftyOverlayBasicGame extends BasicGame {
     inputSystem.setInput(input);
 
     niftyGUI = new Nifty(renderDevice, soundDevice, inputSystem, timeProvider);
+    
+    if (inputSystem instanceof ForwardingInputSystem) {
+      inputForwardingControl = (ForwardingInputSystem) inputSystem;
+    }
 
     /* Slick automatically adds the game as input listener. Undo this. */
     input.removeListener(this);
@@ -138,6 +153,11 @@ public abstract class NiftyOverlayBasicGame extends BasicGame {
    */
   protected final void initNifty(final GameContainer container) {
     initNifty(container, new SlickSlickInputSystem(this));
+  }
+
+  @Override
+  public final boolean isInputForwardingSupported() {
+    return (inputForwardingControl != null);
   }
 
   /**

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/NiftyOverlayBasicGame.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/NiftyOverlayBasicGame.java
@@ -1,11 +1,5 @@
 package de.lessvoid.nifty.slick2d;
 
-import org.newdawn.slick.BasicGame;
-import org.newdawn.slick.GameContainer;
-import org.newdawn.slick.Graphics;
-import org.newdawn.slick.Input;
-import org.newdawn.slick.SlickException;
-
 import de.lessvoid.nifty.Nifty;
 import de.lessvoid.nifty.slick2d.input.SlickInputSystem;
 import de.lessvoid.nifty.slick2d.input.SlickSlickInputSystem;
@@ -13,23 +7,23 @@ import de.lessvoid.nifty.slick2d.render.SlickRenderDevice;
 import de.lessvoid.nifty.slick2d.sound.SlickSoundDevice;
 import de.lessvoid.nifty.slick2d.time.LWJGLTimeProvider;
 import de.lessvoid.nifty.spi.time.TimeProvider;
+import org.newdawn.slick.*;
 
 /**
  * This class implements a Slick Basic game with a NiftyGUI Overlay.
- * 
+ *
  * @author Martin Karing &lt;nitram@illarion.org&gt;
  */
 public abstract class NiftyOverlayBasicGame extends BasicGame {
   /**
    * The one and only Nifty GUI.
    */
-  private Nifty niftyGUI;
+  private Nifty niftyGUI = null;
 
   /**
    * Forward constructor to set the title of the game.
-   * 
-   * @param title
-   *          the title of the game
+   *
+   * @param title the title of the game
    */
   protected NiftyOverlayBasicGame(final String title) {
     super(title);
@@ -37,7 +31,7 @@ public abstract class NiftyOverlayBasicGame extends BasicGame {
 
   /**
    * Get the instance of the NiftyGUI that is used to render this screen.
-   * 
+   *
    * @return the instance of the NiftyGUI
    */
   public final Nifty getNifty() {
@@ -57,37 +51,27 @@ public abstract class NiftyOverlayBasicGame extends BasicGame {
   }
 
   /**
-   * Initialize the game. This function is called during
-   * {@link #init(GameContainer)}. During this call its needed to initialize the
-   * Nifty GUI with own options by calling
-   * {@link #initNifty(GameContainer, SlickRenderDevice, SlickSoundDevice, SlickInputSystem, TimeProvider)}
-   * .
-   * 
-   * @param container
-   *          the game container that displays the game
-   * @throws SlickException
-   *           in case initializing the game goes wrong
+   * Initialize the game. This function is called during {@link #init(GameContainer)}. During this call its needed to
+   * initialize the Nifty GUI with own options by calling {@link #initNifty(GameContainer, SlickRenderDevice,
+   * SlickSoundDevice, SlickInputSystem, TimeProvider)} .
+   *
+   * @param container the game container that displays the game
+   * @throws SlickException in case initializing the game goes wrong
    */
-  protected abstract void initGameAndGUI(final GameContainer container) throws SlickException;
+  protected abstract void initGameAndGUI(GameContainer container) throws SlickException;
 
   /**
    * Initialize the Nifty GUI for this game.
-   * 
-   * @param container
-   *          the container used to display the game
-   * @param renderDevice
-   *          the render device that is supposed to be used to render the GUI
-   * @param soundDevice
-   *          the sound device that is supposed to be used
-   * @param inputSystem
-   *          the input system that is supposed to be used
-   * @param timeProvider
-   *          the time provider that is supposed to be used
-   * @throws IllegalStateException
-   *           in case this function was called before
+   *
+   * @param container the container used to display the game
+   * @param renderDevice the render device that is supposed to be used to render the GUI
+   * @param soundDevice the sound device that is supposed to be used
+   * @param inputSystem the input system that is supposed to be used
+   * @param timeProvider the time provider that is supposed to be used
+   * @throws IllegalStateException in case this function was called before
    */
   protected final void initNifty(
-      final GameContainer container,
+      @SuppressWarnings("TypeMayBeWeakened") final GameContainer container,
       final SlickRenderDevice renderDevice,
       final SlickSoundDevice soundDevice,
       final SlickInputSystem inputSystem,
@@ -110,19 +94,13 @@ public abstract class NiftyOverlayBasicGame extends BasicGame {
   }
 
   /**
-   * Initialize the Nifty GUI for this game. This function will use the default
-   * {@link de.lessvoid.nifty.spi.time.TimeProvider}.
-   * 
-   * @param container
-   *          the container used to display the game
-   * @param renderDevice
-   *          the render device that is supposed to be used to render the GUI
-   * @param soundDevice
-   *          the sound device that is supposed to be used
-   * @param inputSystem
-   *          the input system that is supposed to be used
-   * @throws IllegalStateException
-   *           in case this function was called before
+   * Initialize the Nifty GUI for this game. This function will use the default {@link TimeProvider}.
+   *
+   * @param container the container used to display the game
+   * @param renderDevice the render device that is supposed to be used to render the GUI
+   * @param soundDevice the sound device that is supposed to be used
+   * @param inputSystem the input system that is supposed to be used
+   * @throws IllegalStateException in case this function was called before
    */
   protected final void initNifty(
       final GameContainer container,
@@ -133,48 +111,40 @@ public abstract class NiftyOverlayBasicGame extends BasicGame {
   }
 
   /**
-   * Initialize the Nifty GUI for this game. This function will use the default
-   * {@link de.lessvoid.nifty.spi.time.TimeProvider}. Also it will use the render
-   * and sound devices that are provided with this library.
-   * 
-   * @param container
-   *          the container used to display the game
-   * @param inputSystem
-   *          the input system that is supposed to be used
-   * @throws IllegalStateException
-   *           in case this function was called before
-   * @see de.lessvoid.nifty.slick2d.render.SlickRenderDevice
-   * @see de.lessvoid.nifty.slick2d.sound.SlickSoundDevice
+   * Initialize the Nifty GUI for this game. This function will use the default {@link TimeProvider}. Also it will use
+   * the render and sound devices that are provided with this library.
+   *
+   * @param container the container used to display the game
+   * @param inputSystem the input system that is supposed to be used
+   * @throws IllegalStateException in case this function was called before
+   * @see SlickRenderDevice
+   * @see SlickSoundDevice
    */
   protected final void initNifty(final GameContainer container, final SlickInputSystem inputSystem) {
     initNifty(container, new SlickRenderDevice(container), new SlickSoundDevice(), inputSystem);
   }
 
   /**
-   * Initialize the Nifty GUI for this game. This function will use the default
-   * {@link de.lessvoid.nifty.spi.time.TimeProvider}. Also it will use the render
-   * and sound devices that are provided with this library. As for the input it
-   * will forward all input to the Slick {@link org.newdawn.slick.InputListener}
-   * that is implemented in this class.
-   * 
-   * @param container
-   *          the container used to display the game
-   * @throws IllegalStateException
-   *           in case this function was called before
-   * @see de.lessvoid.nifty.slick2d.render.SlickRenderDevice
-   * @see de.lessvoid.nifty.slick2d.sound.SlickSoundDevice
-   * @see de.lessvoid.nifty.slick2d.input.SlickSlickInputSystem
+   * Initialize the Nifty GUI for this game. This function will use the default {@link TimeProvider}. Also it will use
+   * the render and sound devices that are provided with this library. As for the input it will forward all input to
+   * the
+   * Slick {@link InputListener} that is implemented in this class.
+   *
+   * @param container the container used to display the game
+   * @throws IllegalStateException in case this function was called before
+   * @see SlickRenderDevice
+   * @see SlickSoundDevice
+   * @see SlickSlickInputSystem
    */
   protected final void initNifty(final GameContainer container) {
     initNifty(container, new SlickSlickInputSystem(this));
   }
 
   /**
-   * This function should be used to prepare the actual GUI and the controllers
-   * of the Nifty GUI. It is called right after the Nifty GUI got initialized.
-   * 
-   * @param nifty
-   *          the Nifty GUI that got initialized
+   * This function should be used to prepare the actual GUI and the controllers of the Nifty GUI. It is called right
+   * after the Nifty GUI got initialized.
+   *
+   * @param nifty the Nifty GUI that got initialized
    */
   protected abstract void prepareNifty(Nifty nifty);
 
@@ -191,15 +161,12 @@ public abstract class NiftyOverlayBasicGame extends BasicGame {
   }
 
   /**
-   * This function is supposed to be used to render the game. It is called
-   * during the call of the {@link #render(GameContainer, Graphics)} function.
-   * 
-   * @param container
-   *          the container that displays the game
-   * @param g
-   *          the graphics instance that is used to draw the game
-   * @throws SlickException
-   *           in case anything goes wrong during the rendering
+   * This function is supposed to be used to render the game. It is called during the call of the {@link
+   * #render(GameContainer, Graphics)} function.
+   *
+   * @param container the container that displays the game
+   * @param g the graphics instance that is used to draw the game
+   * @throws SlickException in case anything goes wrong during the rendering
    */
   protected abstract void renderGame(GameContainer container, Graphics g) throws SlickException;
 
@@ -207,7 +174,7 @@ public abstract class NiftyOverlayBasicGame extends BasicGame {
    * Update the game.
    */
   @Override
-  public final void update(final GameContainer container, final int delta) throws SlickException {    
+  public final void update(final GameContainer container, final int delta) throws SlickException {
     updateGame(container, delta);
 
     if (niftyGUI != null) {
@@ -216,15 +183,12 @@ public abstract class NiftyOverlayBasicGame extends BasicGame {
   }
 
   /**
-   * This function is supposed to be used to update the state of the game. It
-   * called during the call of the {@link #update(GameContainer, int)} function.
-   * 
-   * @param container
-   *          the container that displays the game
-   * @param delta
-   *          the time since the last update
-   * @throws SlickException
-   *           in case anything goes wrong during the update
+   * This function is supposed to be used to update the state of the game. It called during the call of the {@link
+   * #update(GameContainer, int)} function.
+   *
+   * @param container the container that displays the game
+   * @param delta the time since the last update
+   * @throws SlickException in case anything goes wrong during the update
    */
   protected abstract void updateGame(GameContainer container, int delta) throws SlickException;
 }

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/NiftyOverlayBasicGame.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/NiftyOverlayBasicGame.java
@@ -52,7 +52,7 @@ public abstract class NiftyOverlayBasicGame extends BasicGame {
     initGameAndGUI(container);
 
     if (niftyGUI == null) {
-      throw new IllegalArgumentException("NiftyGUI is not initializied!");
+      throw new IllegalArgumentException("NiftyGUI is not initialized!");
     }
   }
 
@@ -60,7 +60,7 @@ public abstract class NiftyOverlayBasicGame extends BasicGame {
    * Initialize the game. This function is called during
    * {@link #init(GameContainer)}. During this call its needed to initialize the
    * Nifty GUI with own options by calling
-   * {@link #initNifty(GameContainer, SlickRenderDevice, SlickSoundDevice, TimeProvider)}
+   * {@link #initNifty(GameContainer, SlickRenderDevice, SlickSoundDevice, SlickInputSystem, TimeProvider)}
    * .
    * 
    * @param container
@@ -111,7 +111,7 @@ public abstract class NiftyOverlayBasicGame extends BasicGame {
 
   /**
    * Initialize the Nifty GUI for this game. This function will use the default
-   * {@link de.lessvoid.nifty.tools.TimeProvider}.
+   * {@link de.lessvoid.nifty.spi.time.TimeProvider}.
    * 
    * @param container
    *          the container used to display the game
@@ -134,7 +134,7 @@ public abstract class NiftyOverlayBasicGame extends BasicGame {
 
   /**
    * Initialize the Nifty GUI for this game. This function will use the default
-   * {@link de.lessvoid.nifty.tools.TimeProvider}. Also it will use the render
+   * {@link de.lessvoid.nifty.spi.time.TimeProvider}. Also it will use the render
    * and sound devices that are provided with this library.
    * 
    * @param container
@@ -152,7 +152,7 @@ public abstract class NiftyOverlayBasicGame extends BasicGame {
 
   /**
    * Initialize the Nifty GUI for this game. This function will use the default
-   * {@link de.lessvoid.nifty.tools.TimeProvider}. Also it will use the render
+   * {@link de.lessvoid.nifty.spi.time.TimeProvider}. Also it will use the render
    * and sound devices that are provided with this library. As for the input it
    * will forward all input to the Slick {@link org.newdawn.slick.InputListener}
    * that is implemented in this class.

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/NiftyOverlayBasicGameState.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/NiftyOverlayBasicGameState.java
@@ -1,12 +1,5 @@
 package de.lessvoid.nifty.slick2d;
 
-import org.newdawn.slick.GameContainer;
-import org.newdawn.slick.Graphics;
-import org.newdawn.slick.Input;
-import org.newdawn.slick.SlickException;
-import org.newdawn.slick.state.BasicGameState;
-import org.newdawn.slick.state.StateBasedGame;
-
 import de.lessvoid.nifty.Nifty;
 import de.lessvoid.nifty.slick2d.input.SlickInputSystem;
 import de.lessvoid.nifty.slick2d.input.SlickSlickInputSystem;
@@ -14,17 +7,20 @@ import de.lessvoid.nifty.slick2d.render.SlickRenderDevice;
 import de.lessvoid.nifty.slick2d.sound.SlickSoundDevice;
 import de.lessvoid.nifty.slick2d.time.LWJGLTimeProvider;
 import de.lessvoid.nifty.spi.time.TimeProvider;
+import org.newdawn.slick.*;
+import org.newdawn.slick.state.BasicGameState;
+import org.newdawn.slick.state.StateBasedGame;
 
 public abstract class NiftyOverlayBasicGameState extends BasicGameState {
   /**
    * The used input system.
    */
-  private SlickInputSystem inputSystem;
+  private SlickInputSystem inSystem = null;
 
   /**
    * The one and only Nifty GUI.
    */
-  private Nifty niftyGUI;
+  private Nifty niftyGUI = null;
 
   /**
    * Enter the game state.
@@ -32,28 +28,25 @@ public abstract class NiftyOverlayBasicGameState extends BasicGameState {
   @Override
   public final void enter(final GameContainer container, final StateBasedGame game) throws SlickException {
     final Input input = container.getInput();
-    input.removeListener(inputSystem);
-    input.addListener(inputSystem);
+    input.removeListener(inSystem);
+    input.addListener(inSystem);
 
     enterState(container, game);
   }
 
   /**
-   * Enter the game state. This function is called during the default
-   * {@link #enter(GameContainer, StateBasedGame)} function call.
-   * 
-   * @param container
-   *          the container that displays the game
-   * @param game
-   *          the state based game this state is a part of
-   * @throws SlickException
-   *           in case entering the state fails
+   * Enter the game state. This function is called during the default {@link #enter(GameContainer, StateBasedGame)}
+   * function call.
+   *
+   * @param container the container that displays the game
+   * @param game the state based game this state is a part of
+   * @throws SlickException in case entering the state fails
    */
-  protected abstract void enterState(final GameContainer container, final StateBasedGame game) throws SlickException;
+  protected abstract void enterState(GameContainer container, StateBasedGame game) throws SlickException;
 
   /**
    * Get the instance of the NiftyGUI that is used to render this screen.
-   * 
+   *
    * @return the instance of the NiftyGUI
    */
   public final Nifty getNifty() {
@@ -75,42 +68,30 @@ public abstract class NiftyOverlayBasicGameState extends BasicGameState {
   }
 
   /**
-   * Initialize the game. This function is called during
-   * {@link #init(GameContainer, StateBasedGame)}. During this call its needed to initialize the
-   * Nifty GUI with own options by calling
-   * {@link #initNifty(GameContainer, StateBasedGame, SlickRenderDevice, SlickSoundDevice, SlickInputSystem,
-   * TimeProvider)}
-   * .
-   * 
-   * @param container
-   *          the game container that displays the game
-   * @param game
-   *          the state based game this state is part of
-   * @throws SlickException
-   *           in case initializing the game goes wrong
+   * Initialize the game. This function is called during {@link #init(GameContainer, StateBasedGame)}. During this call
+   * its needed to initialize the Nifty GUI with own options by calling {@link #initNifty(GameContainer,
+   * StateBasedGame,
+   * SlickRenderDevice, SlickSoundDevice, SlickInputSystem, TimeProvider)} .
+   *
+   * @param container the game container that displays the game
+   * @param game the state based game this state is part of
+   * @throws SlickException in case initializing the game goes wrong
    */
-  protected abstract void initGameAndGUI(final GameContainer container, StateBasedGame game) throws SlickException;
+  protected abstract void initGameAndGUI(GameContainer container, StateBasedGame game) throws SlickException;
 
   /**
    * Initialize the Nifty GUI for this game.
-   * 
-   * @param container
-   *          the container used to display the game
-   * @param game
-   *          the state based game this state is part of
-   * @param renderDevice
-   *          the render device that is supposed to be used to render the GUI
-   * @param soundDevice
-   *          the sound device that is supposed to be used
-   * @param inputSystem
-   *          the input system that is supposed to be used
-   * @param timeProvider
-   *          the time provider that is supposed to be used
-   * @throws IllegalStateException
-   *           in case this function was called before
+   *
+   * @param container the container used to display the game
+   * @param game the state based game this state is part of
+   * @param renderDevice the render device that is supposed to be used to render the GUI
+   * @param soundDevice the sound device that is supposed to be used
+   * @param inputSystem the input system that is supposed to be used
+   * @param timeProvider the time provider that is supposed to be used
+   * @throws IllegalStateException in case this function was called before
    */
   protected final void initNifty(
-      final GameContainer container,
+      @SuppressWarnings("TypeMayBeWeakened") final GameContainer container,
       final StateBasedGame game,
       final SlickRenderDevice renderDevice,
       final SlickSoundDevice soundDevice,
@@ -124,27 +105,20 @@ public abstract class NiftyOverlayBasicGameState extends BasicGameState {
 
     niftyGUI = new Nifty(renderDevice, soundDevice, inputSystem, timeProvider);
 
-    this.inputSystem = inputSystem;
+    inSystem = inputSystem;
 
     prepareNifty(niftyGUI, game);
   }
 
   /**
-   * Initialize the Nifty GUI for this game. This function will use the default
-   * {@link de.lessvoid.nifty.spi.time.TimeProvider}.
-   * 
-   * @param container
-   *          the container used to display the game
-   * @param game
-   *          the state based game this state is part of
-   * @param renderDevice
-   *          the render device that is supposed to be used to render the GUI
-   * @param soundDevice
-   *          the sound device that is supposed to be used
-   * @param inputSystem
-   *          the input system that is supposed to be used
-   * @throws IllegalStateException
-   *           in case this function was called before
+   * Initialize the Nifty GUI for this game. This function will use the default {@link TimeProvider}.
+   *
+   * @param container the container used to display the game
+   * @param game the state based game this state is part of
+   * @param renderDevice the render device that is supposed to be used to render the GUI
+   * @param soundDevice the sound device that is supposed to be used
+   * @param inputSystem the input system that is supposed to be used
+   * @throws IllegalStateException in case this function was called before
    */
   protected final void initNifty(
       final GameContainer container,
@@ -156,44 +130,33 @@ public abstract class NiftyOverlayBasicGameState extends BasicGameState {
   }
 
   /**
-   * Initialize the Nifty GUI for this game. This function will use the default
-   * {@link de.lessvoid.nifty.spi.time.TimeProvider}. Also it will use the render
-   * and sound devices that are provided with this library.
-   * 
-   * @param container
-   *          the container used to display the game
-   * @param game
-   *          the state based game this state is part of
-   * @param inputSystem
-   *          the input system that is supposed to be used
-   * @throws IllegalStateException
-   *           in case this function was called before
-   * @see de.lessvoid.nifty.slick2d.render.SlickRenderDevice
-   * @see de.lessvoid.nifty.slick2d.sound.SlickSoundDevice
+   * Initialize the Nifty GUI for this game. This function will use the default {@link TimeProvider}. Also it will use
+   * the render and sound devices that are provided with this library.
+   *
+   * @param container the container used to display the game
+   * @param game the state based game this state is part of
+   * @param inputSystem the input system that is supposed to be used
+   * @throws IllegalStateException in case this function was called before
+   * @see SlickRenderDevice
+   * @see SlickSoundDevice
    */
   protected final void initNifty(
-      final GameContainer container,
-      final StateBasedGame game,
-      final SlickInputSystem inputSystem) {
+      final GameContainer container, final StateBasedGame game, final SlickInputSystem inputSystem) {
     initNifty(container, game, new SlickRenderDevice(container), new SlickSoundDevice(), inputSystem);
   }
 
   /**
-   * Initialize the Nifty GUI for this game. This function will use the default
-   * {@link de.lessvoid.nifty.spi.time.TimeProvider}. Also it will use the render
-   * and sound devices that are provided with this library. As for the input it
-   * will forward all input to the Slick {@link org.newdawn.slick.InputListener}
-   * that is implemented in this class.
-   * 
-   * @param container
-   *          the container used to display the game
-   * @param game
-   *          the state based game this state is part of
-   * @throws IllegalStateException
-   *           in case this function was called before
-   * @see de.lessvoid.nifty.slick2d.render.SlickRenderDevice
-   * @see de.lessvoid.nifty.slick2d.sound.SlickSoundDevice
-   * @see de.lessvoid.nifty.slick2d.input.SlickSlickInputSystem
+   * Initialize the Nifty GUI for this game. This function will use the default {@link TimeProvider}. Also it will use
+   * the render and sound devices that are provided with this library. As for the input it will forward all input to
+   * the
+   * Slick {@link InputListener} that is implemented in this class.
+   *
+   * @param container the container used to display the game
+   * @param game the state based game this state is part of
+   * @throws IllegalStateException in case this function was called before
+   * @see SlickRenderDevice
+   * @see SlickSoundDevice
+   * @see SlickSlickInputSystem
    */
   protected final void initNifty(final GameContainer container, final StateBasedGame game) {
     initNifty(container, game, new SlickSlickInputSystem(this));
@@ -205,32 +168,27 @@ public abstract class NiftyOverlayBasicGameState extends BasicGameState {
   @Override
   public final void leave(final GameContainer container, final StateBasedGame game) throws SlickException {
     final Input input = container.getInput();
-    input.removeListener(inputSystem);
+    input.removeListener(inSystem);
 
     leaveState(container, game);
   }
 
   /**
-   * Leave the game state. This function is called during the default
-   * {@link #leave(GameContainer, StateBasedGame)} function call.
-   * 
-   * @param container
-   *          the container that displays the game
-   * @param game
-   *          the state based game this state is a part of
-   * @throws SlickException
-   *           in case entering the state fails
+   * Leave the game state. This function is called during the default {@link #leave(GameContainer, StateBasedGame)}
+   * function call.
+   *
+   * @param container the container that displays the game
+   * @param game the state based game this state is a part of
+   * @throws SlickException in case entering the state fails
    */
-  protected abstract void leaveState(final GameContainer container, final StateBasedGame game) throws SlickException;
+  protected abstract void leaveState(GameContainer container, StateBasedGame game) throws SlickException;
 
   /**
-   * This function should be used to prepare the actual GUI and the controllers
-   * of the Nifty GUI. It is called right after the Nifty GUI got initialized.
-   * 
-   * @param nifty
-   *          the Nifty GUI that got initialized
-   * @param game
-   *          the state based game this state is part of
+   * This function should be used to prepare the actual GUI and the controllers of the Nifty GUI. It is called right
+   * after the Nifty GUI got initialized.
+   *
+   * @param nifty the Nifty GUI that got initialized
+   * @param game the state based game this state is part of
    */
   protected abstract void prepareNifty(Nifty nifty, StateBasedGame game);
 
@@ -238,8 +196,8 @@ public abstract class NiftyOverlayBasicGameState extends BasicGameState {
    * Render the game.
    */
   @Override
-  public final void render(final GameContainer container, final StateBasedGame game, final Graphics g)
-      throws SlickException {
+  public final void render(
+      final GameContainer container, final StateBasedGame game, final Graphics g) throws SlickException {
     renderGame(container, game, g);
 
     if (niftyGUI != null) {
@@ -248,17 +206,13 @@ public abstract class NiftyOverlayBasicGameState extends BasicGameState {
   }
 
   /**
-   * This function is supposed to be used to render the game. It is called
-   * during the call of the {@link #render(GameContainer, StateBasedGame, Graphics)} function.
-   * 
-   * @param container
-   *          the container that displays the game
-   * @param game
-   *          the state based game this state is part of
-   * @param g
-   *          the graphics instance that is used to draw the game
-   * @throws SlickException
-   *           in case anything goes wrong during the rendering
+   * This function is supposed to be used to render the game. It is called during the call of the {@link
+   * #render(GameContainer, StateBasedGame, Graphics)} function.
+   *
+   * @param container the container that displays the game
+   * @param game the state based game this state is part of
+   * @param g the graphics instance that is used to draw the game
+   * @throws SlickException in case anything goes wrong during the rendering
    */
   protected abstract void renderGame(GameContainer container, StateBasedGame game, Graphics g) throws SlickException;
 
@@ -266,8 +220,8 @@ public abstract class NiftyOverlayBasicGameState extends BasicGameState {
    * Update the game.
    */
   @Override
-  public final void update(final GameContainer container, final StateBasedGame game, final int delta)
-      throws SlickException {
+  public final void update(
+      final GameContainer container, final StateBasedGame game, final int delta) throws SlickException {
     updateGame(container, game, delta);
 
     if (niftyGUI != null) {
@@ -276,17 +230,13 @@ public abstract class NiftyOverlayBasicGameState extends BasicGameState {
   }
 
   /**
-   * This function is supposed to be used to update the state of the game. It
-   * called during the call of the {@link #update(GameContainer, StateBasedGame, int)} function.
-   * 
-   * @param container
-   *          the container that displays the game
-   * @param game
-   *          the state based game this state is part of
-   * @param delta
-   *          the time since the last update
-   * @throws SlickException
-   *           in case anything goes wrong during the update
+   * This function is supposed to be used to update the state of the game. It called during the call of the {@link
+   * #update(GameContainer, StateBasedGame, int)} function.
+   *
+   * @param container the container that displays the game
+   * @param game the state based game this state is part of
+   * @param delta the time since the last update
+   * @throws SlickException in case anything goes wrong during the update
    */
   protected abstract void updateGame(GameContainer container, StateBasedGame game, int delta) throws SlickException;
 }

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/NiftyOverlayBasicGameState.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/NiftyOverlayBasicGameState.java
@@ -76,13 +76,16 @@ public abstract class NiftyOverlayBasicGameState extends BasicGameState {
 
   /**
    * Initialize the game. This function is called during
-   * {@link #init(GameContainer)}. During this call its needed to initialize the
+   * {@link #init(GameContainer, StateBasedGame)}. During this call its needed to initialize the
    * Nifty GUI with own options by calling
-   * {@link #initNifty(GameContainer, SlickRenderDevice, SlickSoundDevice, TimeProvider)}
+   * {@link #initNifty(GameContainer, StateBasedGame, SlickRenderDevice, SlickSoundDevice, SlickInputSystem,
+   * TimeProvider)}
    * .
    * 
    * @param container
    *          the game container that displays the game
+   * @param game
+   *          the state based game this state is part of
    * @throws SlickException
    *           in case initializing the game goes wrong
    */
@@ -128,7 +131,7 @@ public abstract class NiftyOverlayBasicGameState extends BasicGameState {
 
   /**
    * Initialize the Nifty GUI for this game. This function will use the default
-   * {@link de.lessvoid.nifty.tools.TimeProvider}.
+   * {@link de.lessvoid.nifty.spi.time.TimeProvider}.
    * 
    * @param container
    *          the container used to display the game
@@ -154,7 +157,7 @@ public abstract class NiftyOverlayBasicGameState extends BasicGameState {
 
   /**
    * Initialize the Nifty GUI for this game. This function will use the default
-   * {@link de.lessvoid.nifty.tools.TimeProvider}. Also it will use the render
+   * {@link de.lessvoid.nifty.spi.time.TimeProvider}. Also it will use the render
    * and sound devices that are provided with this library.
    * 
    * @param container
@@ -177,7 +180,7 @@ public abstract class NiftyOverlayBasicGameState extends BasicGameState {
 
   /**
    * Initialize the Nifty GUI for this game. This function will use the default
-   * {@link de.lessvoid.nifty.tools.TimeProvider}. Also it will use the render
+   * {@link de.lessvoid.nifty.spi.time.TimeProvider}. Also it will use the render
    * and sound devices that are provided with this library. As for the input it
    * will forward all input to the Slick {@link org.newdawn.slick.InputListener}
    * that is implemented in this class.
@@ -246,10 +249,12 @@ public abstract class NiftyOverlayBasicGameState extends BasicGameState {
 
   /**
    * This function is supposed to be used to render the game. It is called
-   * during the call of the {@link #render(GameContainer, Graphics)} function.
+   * during the call of the {@link #render(GameContainer, StateBasedGame, Graphics)} function.
    * 
    * @param container
    *          the container that displays the game
+   * @param game
+   *          the state based game this state is part of
    * @param g
    *          the graphics instance that is used to draw the game
    * @throws SlickException
@@ -272,10 +277,12 @@ public abstract class NiftyOverlayBasicGameState extends BasicGameState {
 
   /**
    * This function is supposed to be used to update the state of the game. It
-   * called during the call of the {@link #update(GameContainer, int)} function.
+   * called during the call of the {@link #update(GameContainer, StateBasedGame, int)} function.
    * 
    * @param container
    *          the container that displays the game
+   * @param game
+   *          the state based game this state is part of
    * @param delta
    *          the time since the last update
    * @throws SlickException

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/NiftyOverlayBasicGameState.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/NiftyOverlayBasicGameState.java
@@ -1,6 +1,7 @@
 package de.lessvoid.nifty.slick2d;
 
 import de.lessvoid.nifty.Nifty;
+import de.lessvoid.nifty.slick2d.input.ForwardingInputSystem;
 import de.lessvoid.nifty.slick2d.input.SlickInputSystem;
 import de.lessvoid.nifty.slick2d.input.SlickSlickInputSystem;
 import de.lessvoid.nifty.slick2d.render.SlickRenderDevice;
@@ -11,7 +12,7 @@ import org.newdawn.slick.*;
 import org.newdawn.slick.state.BasicGameState;
 import org.newdawn.slick.state.StateBasedGame;
 
-public abstract class NiftyOverlayBasicGameState extends BasicGameState {
+public abstract class NiftyOverlayBasicGameState extends BasicGameState implements NiftyInputForwarding {
   /**
    * The used input system.
    */
@@ -21,6 +22,11 @@ public abstract class NiftyOverlayBasicGameState extends BasicGameState {
    * The one and only Nifty GUI.
    */
   private Nifty niftyGUI = null;
+
+  /**
+   * This variable provides the control over the forwarding implementations.
+   */
+  private ForwardingInputSystem inputForwardingControl;
 
   /**
    * Enter the game state.
@@ -51,6 +57,11 @@ public abstract class NiftyOverlayBasicGameState extends BasicGameState {
    */
   public final Nifty getNifty() {
     return niftyGUI;
+  }
+
+  @Override
+  public final ForwardingInputSystem getInputForwardingControl() {
+    return inputForwardingControl;
   }
 
   /**
@@ -104,6 +115,10 @@ public abstract class NiftyOverlayBasicGameState extends BasicGameState {
     inputSystem.setInput(container.getInput());
 
     niftyGUI = new Nifty(renderDevice, soundDevice, inputSystem, timeProvider);
+
+    if (inputSystem instanceof ForwardingInputSystem) {
+      inputForwardingControl = (ForwardingInputSystem) inputSystem;
+    }
 
     inSystem = inputSystem;
 
@@ -160,6 +175,11 @@ public abstract class NiftyOverlayBasicGameState extends BasicGameState {
    */
   protected final void initNifty(final GameContainer container, final StateBasedGame game) {
     initNifty(container, game, new SlickSlickInputSystem(this));
+  }
+
+  @Override
+  public final boolean isInputForwardingSupported() {
+    return (inputForwardingControl != null);
   }
 
   /**

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/NiftyOverlayGame.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/NiftyOverlayGame.java
@@ -1,11 +1,5 @@
 package de.lessvoid.nifty.slick2d;
 
-import org.newdawn.slick.Game;
-import org.newdawn.slick.GameContainer;
-import org.newdawn.slick.Graphics;
-import org.newdawn.slick.Input;
-import org.newdawn.slick.SlickException;
-
 import de.lessvoid.nifty.Nifty;
 import de.lessvoid.nifty.slick2d.input.PlainSlickInputSystem;
 import de.lessvoid.nifty.slick2d.input.SlickInputSystem;
@@ -13,22 +7,22 @@ import de.lessvoid.nifty.slick2d.render.SlickRenderDevice;
 import de.lessvoid.nifty.slick2d.sound.SlickSoundDevice;
 import de.lessvoid.nifty.slick2d.time.LWJGLTimeProvider;
 import de.lessvoid.nifty.spi.time.TimeProvider;
+import org.newdawn.slick.*;
 
 /**
- * This game implementation creates a Slick Game that is able to Overlay the
- * game itself with a Nifty GUI.
- * 
+ * This game implementation creates a Slick Game that is able to Overlay the game itself with a Nifty GUI.
+ *
  * @author Martin Karing &lt;nitram@illarion.org&gt;
  */
 public abstract class NiftyOverlayGame implements Game {
   /**
    * The one and only Nifty GUI.
    */
-  private Nifty niftyGUI;
+  private Nifty niftyGUI = null;
 
   /**
    * Get the instance of the NiftyGUI that is used to render this screen.
-   * 
+   *
    * @return the instance of the NiftyGUI
    */
   public final Nifty getNifty() {
@@ -48,37 +42,27 @@ public abstract class NiftyOverlayGame implements Game {
   }
 
   /**
-   * Initialize the game. This function is called during
-   * {@link #init(GameContainer)}. During this call its needed to initialize the
-   * Nifty GUI with own options by calling
-   * {@link #initNifty(GameContainer, SlickRenderDevice, SlickSoundDevice, SlickInputSystem, TimeProvider)}
-   * .
-   * 
-   * @param container
-   *          the game container that displays the game
-   * @throws SlickException
-   *           in case initializing the game goes wrong
+   * Initialize the game. This function is called during {@link #init(GameContainer)}. During this call its needed to
+   * initialize the Nifty GUI with own options by calling {@link #initNifty(GameContainer, SlickRenderDevice,
+   * SlickSoundDevice, SlickInputSystem, TimeProvider)} .
+   *
+   * @param container the game container that displays the game
+   * @throws SlickException in case initializing the game goes wrong
    */
-  protected abstract void initGameAndGUI(final GameContainer container) throws SlickException;
+  protected abstract void initGameAndGUI(GameContainer container) throws SlickException;
 
   /**
    * Initialize the Nifty GUI for this game.
-   * 
-   * @param container
-   *          the container used to display the game
-   * @param renderDevice
-   *          the render device that is supposed to be used to render the GUI
-   * @param soundDevice
-   *          the sound device that is supposed to be used
-   * @param inputSystem
-   *          the input system that is supposed to be used
-   * @param timeProvider
-   *          the time provider that is supposed to be used
-   * @throws IllegalStateException
-   *           in case this function was called before
+   *
+   * @param container the container used to display the game
+   * @param renderDevice the render device that is supposed to be used to render the GUI
+   * @param soundDevice the sound device that is supposed to be used
+   * @param inputSystem the input system that is supposed to be used
+   * @param timeProvider the time provider that is supposed to be used
+   * @throws IllegalStateException in case this function was called before
    */
   protected final void initNifty(
-      final GameContainer container,
+      @SuppressWarnings("TypeMayBeWeakened") final GameContainer container,
       final SlickRenderDevice renderDevice,
       final SlickSoundDevice soundDevice,
       final SlickInputSystem inputSystem,
@@ -99,19 +83,13 @@ public abstract class NiftyOverlayGame implements Game {
   }
 
   /**
-   * Initialize the Nifty GUI for this game. This function will use the default
-   * {@link de.lessvoid.nifty.spi.time.TimeProvider}.
-   * 
-   * @param container
-   *          the container used to display the game
-   * @param renderDevice
-   *          the render device that is supposed to be used to render the GUI
-   * @param soundDevice
-   *          the sound device that is supposed to be used
-   * @param inputSystem
-   *          the input system that is supposed to be used
-   * @throws IllegalStateException
-   *           in case this function was called before
+   * Initialize the Nifty GUI for this game. This function will use the default {@link TimeProvider}.
+   *
+   * @param container the container used to display the game
+   * @param renderDevice the render device that is supposed to be used to render the GUI
+   * @param soundDevice the sound device that is supposed to be used
+   * @param inputSystem the input system that is supposed to be used
+   * @throws IllegalStateException in case this function was called before
    */
   protected final void initNifty(
       final GameContainer container,
@@ -122,48 +100,40 @@ public abstract class NiftyOverlayGame implements Game {
   }
 
   /**
-   * Initialize the Nifty GUI for this game. This function will use the default
-   * {@link de.lessvoid.nifty.spi.time.TimeProvider}. Also it will use the render
-   * and sound devices that are provided with this library.
-   * 
-   * @param container
-   *          the container used to display the game
-   * @param inputSystem
-   *          the input system that is supposed to be used
-   * @throws IllegalStateException
-   *           in case this function was called before
-   * @see de.lessvoid.nifty.slick2d.render.SlickRenderDevice
-   * @see de.lessvoid.nifty.slick2d.sound.SlickSoundDevice
+   * Initialize the Nifty GUI for this game. This function will use the default {@link TimeProvider}. Also it will use
+   * the render and sound devices that are provided with this library.
+   *
+   * @param container the container used to display the game
+   * @param inputSystem the input system that is supposed to be used
+   * @throws IllegalStateException in case this function was called before
+   * @see SlickRenderDevice
+   * @see SlickSoundDevice
    */
   protected final void initNifty(final GameContainer container, final SlickInputSystem inputSystem) {
     initNifty(container, new SlickRenderDevice(container), new SlickSoundDevice(), inputSystem);
   }
 
   /**
-   * Initialize the Nifty GUI for this game. This function will use the default
-   * {@link de.lessvoid.nifty.spi.time.TimeProvider}. Also it will use the render
-   * and sound devices that are provided with this library. As for the input
-   * the a system will be implemented that forwards the commands <i>only</i> to
-   * the Nifty-GUI.
-   * 
-   * @param container
-   *          the container used to display the game
-   * @throws IllegalStateException
-   *           in case this function was called before
-   * @see de.lessvoid.nifty.slick2d.render.SlickRenderDevice
-   * @see de.lessvoid.nifty.slick2d.sound.SlickSoundDevice
-   * @see de.lessvoid.nifty.slick2d.input.PlainSlickInputSystem
+   * Initialize the Nifty GUI for this game. This function will use the default {@link TimeProvider}. Also it will use
+   * the render and sound devices that are provided with this library. As for the input the a system will be
+   * implemented
+   * that forwards the commands <i>only</i> to the Nifty-GUI.
+   *
+   * @param container the container used to display the game
+   * @throws IllegalStateException in case this function was called before
+   * @see SlickRenderDevice
+   * @see SlickSoundDevice
+   * @see PlainSlickInputSystem
    */
   protected final void initNifty(final GameContainer container) {
     initNifty(container, new PlainSlickInputSystem());
   }
 
   /**
-   * This function should be used to prepare the actual GUI and the controllers
-   * of the Nifty GUI. It is called right after the Nifty GUI got initialized.
-   * 
-   * @param nifty
-   *          the Nifty GUI that got initialized
+   * This function should be used to prepare the actual GUI and the controllers of the Nifty GUI. It is called right
+   * after the Nifty GUI got initialized.
+   *
+   * @param nifty the Nifty GUI that got initialized
    */
   protected abstract void prepareNifty(Nifty nifty);
 
@@ -180,15 +150,12 @@ public abstract class NiftyOverlayGame implements Game {
   }
 
   /**
-   * This function is supposed to be used to render the game. It is called
-   * during the call of the {@link #render(GameContainer, Graphics)} function.
-   * 
-   * @param container
-   *          the container that displays the game
-   * @param g
-   *          the graphics instance that is used to draw the game
-   * @throws SlickException
-   *           in case anything goes wrong during the rendering
+   * This function is supposed to be used to render the game. It is called during the call of the {@link
+   * #render(GameContainer, Graphics)} function.
+   *
+   * @param container the container that displays the game
+   * @param g the graphics instance that is used to draw the game
+   * @throws SlickException in case anything goes wrong during the rendering
    */
   protected abstract void renderGame(GameContainer container, Graphics g) throws SlickException;
 
@@ -205,15 +172,12 @@ public abstract class NiftyOverlayGame implements Game {
   }
 
   /**
-   * This function is supposed to be used to update the state of the game. It
-   * called during the call of the {@link #update(GameContainer, int)} function.
-   * 
-   * @param container
-   *          the container that displays the game
-   * @param delta
-   *          the time since the last update
-   * @throws SlickException
-   *           in case anything goes wrong during the update
+   * This function is supposed to be used to update the state of the game. It called during the call of the {@link
+   * #update(GameContainer, int)} function.
+   *
+   * @param container the container that displays the game
+   * @param delta the time since the last update
+   * @throws SlickException in case anything goes wrong during the update
    */
   protected abstract void updateGame(GameContainer container, int delta) throws SlickException;
 }

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/NiftyOverlayGame.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/NiftyOverlayGame.java
@@ -100,7 +100,7 @@ public abstract class NiftyOverlayGame implements Game {
 
   /**
    * Initialize the Nifty GUI for this game. This function will use the default
-   * {@link de.lessvoid.nifty.tools.TimeProvider}.
+   * {@link de.lessvoid.nifty.spi.time.TimeProvider}.
    * 
    * @param container
    *          the container used to display the game
@@ -123,7 +123,7 @@ public abstract class NiftyOverlayGame implements Game {
 
   /**
    * Initialize the Nifty GUI for this game. This function will use the default
-   * {@link de.lessvoid.nifty.tools.TimeProvider}. Also it will use the render
+   * {@link de.lessvoid.nifty.spi.time.TimeProvider}. Also it will use the render
    * and sound devices that are provided with this library.
    * 
    * @param container
@@ -141,7 +141,7 @@ public abstract class NiftyOverlayGame implements Game {
 
   /**
    * Initialize the Nifty GUI for this game. This function will use the default
-   * {@link de.lessvoid.nifty.tools.TimeProvider}. Also it will use the render
+   * {@link de.lessvoid.nifty.spi.time.TimeProvider}. Also it will use the render
    * and sound devices that are provided with this library. As for the input
    * the a system will be implemented that forwards the commands <i>only</i> to
    * the Nifty-GUI.

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/NiftyOverlayGame.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/NiftyOverlayGame.java
@@ -15,7 +15,7 @@ import org.newdawn.slick.*;
  *
  * @author Martin Karing &lt;nitram@illarion.org&gt;
  */
-public abstract class NiftyOverlayGame implements Game, NiftyInputForwarding {
+public abstract class NiftyOverlayGame implements Game, NiftyInputForwarding, NiftyOrderControl {
   /**
    * The one and only Nifty GUI.
    */
@@ -25,6 +25,24 @@ public abstract class NiftyOverlayGame implements Game, NiftyInputForwarding {
    * This variable provides the control over the forwarding implementations.
    */
   private ForwardingInputSystem inputForwardingControl;
+
+  /**
+   * The render order that is used in this game.
+   */
+  private NiftyRenderOrder renderOrder;
+
+  /**
+   * The update order that is used in this game.
+   */
+  private NiftyUpdateOrder updateOrder;
+
+  /**
+   * Default constructor.
+   */
+  protected NiftyOverlayGame() {
+    setRenderOrder(NiftyRenderOrder.NiftyOverlay);
+    setUpdateOrder(NiftyUpdateOrder.NiftyLast);
+  }
 
   /**
    * Get the instance of the NiftyGUI that is used to render this screen.
@@ -162,10 +180,19 @@ public abstract class NiftyOverlayGame implements Game, NiftyInputForwarding {
    */
   @Override
   public final void render(final GameContainer container, final Graphics g) throws SlickException {
-    renderGame(container, g);
-
-    if (niftyGUI != null) {
-      niftyGUI.render(false);
+    if (niftyGUI == null) {
+      renderGame(container, g);
+    } else {
+      switch (renderOrder) {
+        case NiftyOverlay:
+          renderGame(container, g);
+          niftyGUI.render(false);
+          break;
+        case NiftyBackground:
+          niftyGUI.render(true);
+          renderGame(container, g);
+          break;
+      }
     }
   }
 
@@ -184,10 +211,19 @@ public abstract class NiftyOverlayGame implements Game, NiftyInputForwarding {
    */
   @Override
   public final void update(final GameContainer container, final int delta) throws SlickException {
-    updateGame(container, delta);
-
-    if (niftyGUI != null) {
-      niftyGUI.update();
+    if (niftyGUI == null) {
+      updateGame(container, delta);
+    } else {
+      switch (updateOrder) {
+        case NiftyLast:
+          updateGame(container, delta);
+          niftyGUI.update();
+          break;
+        case NiftyFirst:
+          niftyGUI.update();
+          updateGame(container, delta);
+          break;
+      }
     }
   }
 
@@ -200,4 +236,24 @@ public abstract class NiftyOverlayGame implements Game, NiftyInputForwarding {
    * @throws SlickException in case anything goes wrong during the update
    */
   protected abstract void updateGame(GameContainer container, int delta) throws SlickException;
+
+  @Override
+  public final NiftyRenderOrder getRenderOrder() {
+    return renderOrder;
+  }
+
+  @Override
+  public final NiftyUpdateOrder getUpdateOrder() {
+    return updateOrder;
+  }
+
+  @Override
+  public final void setRenderOrder(NiftyRenderOrder order) {
+    renderOrder = order;
+  }
+
+  @Override
+  public final void setUpdateOrder(NiftyUpdateOrder order) {
+    updateOrder = order;
+  }
 }

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/NiftyOverlayGame.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/NiftyOverlayGame.java
@@ -1,6 +1,7 @@
 package de.lessvoid.nifty.slick2d;
 
 import de.lessvoid.nifty.Nifty;
+import de.lessvoid.nifty.slick2d.input.ForwardingInputSystem;
 import de.lessvoid.nifty.slick2d.input.PlainSlickInputSystem;
 import de.lessvoid.nifty.slick2d.input.SlickInputSystem;
 import de.lessvoid.nifty.slick2d.render.SlickRenderDevice;
@@ -14,11 +15,16 @@ import org.newdawn.slick.*;
  *
  * @author Martin Karing &lt;nitram@illarion.org&gt;
  */
-public abstract class NiftyOverlayGame implements Game {
+public abstract class NiftyOverlayGame implements Game, NiftyInputForwarding {
   /**
    * The one and only Nifty GUI.
    */
   private Nifty niftyGUI = null;
+
+  /**
+   * This variable provides the control over the forwarding implementations.
+   */
+  private ForwardingInputSystem inputForwardingControl;
 
   /**
    * Get the instance of the NiftyGUI that is used to render this screen.
@@ -27,6 +33,11 @@ public abstract class NiftyOverlayGame implements Game {
    */
   public final Nifty getNifty() {
     return niftyGUI;
+  }
+
+  @Override
+  public final ForwardingInputSystem getInputForwardingControl() {
+    return inputForwardingControl;
   }
 
   /**
@@ -75,6 +86,10 @@ public abstract class NiftyOverlayGame implements Game {
     inputSystem.setInput(input);
 
     niftyGUI = new Nifty(renderDevice, soundDevice, inputSystem, timeProvider);
+
+    if (inputSystem instanceof ForwardingInputSystem) {
+      inputForwardingControl = (ForwardingInputSystem) inputSystem;
+    }
 
     input.removeListener(inputSystem);
     input.addListener(inputSystem);
@@ -127,6 +142,11 @@ public abstract class NiftyOverlayGame implements Game {
    */
   protected final void initNifty(final GameContainer container) {
     initNifty(container, new PlainSlickInputSystem());
+  }
+
+  @Override
+  public final boolean isInputForwardingSupported() {
+    return inputForwardingControl != null;
   }
 
   /**

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/NiftyOverlayGameState.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/NiftyOverlayGameState.java
@@ -1,6 +1,7 @@
 package de.lessvoid.nifty.slick2d;
 
 import de.lessvoid.nifty.Nifty;
+import de.lessvoid.nifty.slick2d.input.ForwardingInputSystem;
 import de.lessvoid.nifty.slick2d.input.SlickInputSystem;
 import de.lessvoid.nifty.slick2d.input.SlickSlickInputSystem;
 import de.lessvoid.nifty.slick2d.render.SlickRenderDevice;
@@ -11,7 +12,7 @@ import org.newdawn.slick.*;
 import org.newdawn.slick.state.GameState;
 import org.newdawn.slick.state.StateBasedGame;
 
-public abstract class NiftyOverlayGameState implements GameState {
+public abstract class NiftyOverlayGameState implements GameState, NiftyInputForwarding {
   /**
    * The input system that is used by this game state.
    */
@@ -21,6 +22,11 @@ public abstract class NiftyOverlayGameState implements GameState {
    * The one and only Nifty GUI.
    */
   private Nifty niftyGUI = null;
+
+  /**
+   * This variable provides the control over the forwarding implementations.
+   */
+  private ForwardingInputSystem inputForwardingControl;
 
   /**
    * Enter the game state.
@@ -51,6 +57,11 @@ public abstract class NiftyOverlayGameState implements GameState {
    */
   public final Nifty getNifty() {
     return niftyGUI;
+  }
+
+  @Override
+  public final ForwardingInputSystem getInputForwardingControl() {
+    return inputForwardingControl;
   }
 
   /**
@@ -104,6 +115,10 @@ public abstract class NiftyOverlayGameState implements GameState {
     inputSystem.setInput(container.getInput());
 
     niftyGUI = new Nifty(renderDevice, soundDevice, inputSystem, timeProvider);
+
+    if (inputSystem instanceof ForwardingInputSystem) {
+      inputForwardingControl = (ForwardingInputSystem) inputSystem;
+    }
 
     inSystem = inputSystem;
 
@@ -160,6 +175,11 @@ public abstract class NiftyOverlayGameState implements GameState {
    */
   protected final void initNifty(final GameContainer container, final StateBasedGame game) {
     initNifty(container, game, new SlickSlickInputSystem(this));
+  }
+
+  @Override
+  public final boolean isInputForwardingSupported() {
+    return inputForwardingControl != null;
   }
 
   /**

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/NiftyOverlayGameState.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/NiftyOverlayGameState.java
@@ -12,7 +12,7 @@ import org.newdawn.slick.*;
 import org.newdawn.slick.state.GameState;
 import org.newdawn.slick.state.StateBasedGame;
 
-public abstract class NiftyOverlayGameState implements GameState, NiftyInputForwarding {
+public abstract class NiftyOverlayGameState implements GameState, NiftyInputForwarding, NiftyOrderControl {
   /**
    * The input system that is used by this game state.
    */
@@ -27,6 +27,49 @@ public abstract class NiftyOverlayGameState implements GameState, NiftyInputForw
    * This variable provides the control over the forwarding implementations.
    */
   private ForwardingInputSystem inputForwardingControl;
+
+  /**
+   * The render order that is used in this game.
+   */
+  private NiftyRenderOrder renderOrder;
+
+  /**
+   * The update order that is used in this game.
+   */
+  private NiftyUpdateOrder updateOrder;
+
+  /**
+   * Default constructor.
+   */
+  protected NiftyOverlayGameState() {
+    setRenderOrder(NiftyRenderOrder.NiftyOverlay);
+    setUpdateOrder(NiftyUpdateOrder.NiftyLast);
+  }
+
+  @Override
+  public final ForwardingInputSystem getInputForwardingControl() {
+    return inputForwardingControl;
+  }
+
+  @Override
+  public final NiftyRenderOrder getRenderOrder() {
+    return renderOrder;
+  }
+
+  @Override
+  public final void setRenderOrder(NiftyRenderOrder order) {
+    renderOrder = order;
+  }
+
+  @Override
+  public final NiftyUpdateOrder getUpdateOrder() {
+    return updateOrder;
+  }
+
+  @Override
+  public final void setUpdateOrder(NiftyUpdateOrder order) {
+    updateOrder = order;
+  }
 
   /**
    * Enter the game state.
@@ -59,11 +102,6 @@ public abstract class NiftyOverlayGameState implements GameState, NiftyInputForw
     return niftyGUI;
   }
 
-  @Override
-  public final ForwardingInputSystem getInputForwardingControl() {
-    return inputForwardingControl;
-  }
-
   /**
    * Initialize the game and the GUI.
    */
@@ -89,6 +127,58 @@ public abstract class NiftyOverlayGameState implements GameState, NiftyInputForw
    * @throws SlickException in case initializing the game goes wrong
    */
   protected abstract void initGameAndGUI(GameContainer container, StateBasedGame game) throws SlickException;
+
+  /**
+   * Initialize the Nifty GUI for this game. This function will use the default {@link TimeProvider}. Also it will use
+   * the render and sound devices that are provided with this library. As for the input it will forward all input to
+   * the
+   * Slick {@link InputListener} that is implemented in this class.
+   *
+   * @param container the container used to display the game
+   * @param game the game this state is part of
+   * @throws IllegalStateException in case this function was called before
+   * @see SlickRenderDevice
+   * @see SlickSoundDevice
+   * @see SlickSlickInputSystem
+   */
+  protected final void initNifty(final GameContainer container, final StateBasedGame game) {
+    initNifty(container, game, new SlickSlickInputSystem(this));
+  }
+
+  /**
+   * Initialize the Nifty GUI for this game. This function will use the default {@link TimeProvider}. Also it will use
+   * the render and sound devices that are provided with this library.
+   *
+   * @param container the container used to display the game
+   * @param game the game this state is part of
+   * @param inputSystem the input system that is supposed to be used
+   * @throws IllegalStateException in case this function was called before
+   * @see SlickRenderDevice
+   * @see SlickSoundDevice
+   */
+  protected final void initNifty(
+      final GameContainer container, final StateBasedGame game, final SlickInputSystem inputSystem) {
+    initNifty(container, game, new SlickRenderDevice(container), new SlickSoundDevice(), inputSystem);
+  }
+
+  /**
+   * Initialize the Nifty GUI for this game. This function will use the default {@link TimeProvider}.
+   *
+   * @param container the container used to display the game
+   * @param game the game this state is part of
+   * @param renderDevice the render device that is supposed to be used to render the GUI
+   * @param soundDevice the sound device that is supposed to be used
+   * @param inputSystem the input system that is supposed to be used
+   * @throws IllegalStateException in case this function was called before
+   */
+  protected final void initNifty(
+      final GameContainer container,
+      final StateBasedGame game,
+      final SlickRenderDevice renderDevice,
+      final SlickSoundDevice soundDevice,
+      final SlickInputSystem inputSystem) {
+    initNifty(container, game, renderDevice, soundDevice, inputSystem, new LWJGLTimeProvider());
+  }
 
   /**
    * Initialize the Nifty GUI for this game.
@@ -126,56 +216,13 @@ public abstract class NiftyOverlayGameState implements GameState, NiftyInputForw
   }
 
   /**
-   * Initialize the Nifty GUI for this game. This function will use the default {@link TimeProvider}.
+   * This function should be used to prepare the actual GUI and the controllers of the Nifty GUI. It is called right
+   * after the Nifty GUI got initialized.
    *
-   * @param container the container used to display the game
+   * @param nifty the Nifty GUI that got initialized
    * @param game the game this state is part of
-   * @param renderDevice the render device that is supposed to be used to render the GUI
-   * @param soundDevice the sound device that is supposed to be used
-   * @param inputSystem the input system that is supposed to be used
-   * @throws IllegalStateException in case this function was called before
    */
-  protected final void initNifty(
-      final GameContainer container,
-      final StateBasedGame game,
-      final SlickRenderDevice renderDevice,
-      final SlickSoundDevice soundDevice,
-      final SlickInputSystem inputSystem) {
-    initNifty(container, game, renderDevice, soundDevice, inputSystem, new LWJGLTimeProvider());
-  }
-
-  /**
-   * Initialize the Nifty GUI for this game. This function will use the default {@link TimeProvider}. Also it will use
-   * the render and sound devices that are provided with this library.
-   *
-   * @param container the container used to display the game
-   * @param game the game this state is part of
-   * @param inputSystem the input system that is supposed to be used
-   * @throws IllegalStateException in case this function was called before
-   * @see SlickRenderDevice
-   * @see SlickSoundDevice
-   */
-  protected final void initNifty(
-      final GameContainer container, final StateBasedGame game, final SlickInputSystem inputSystem) {
-    initNifty(container, game, new SlickRenderDevice(container), new SlickSoundDevice(), inputSystem);
-  }
-
-  /**
-   * Initialize the Nifty GUI for this game. This function will use the default {@link TimeProvider}. Also it will use
-   * the render and sound devices that are provided with this library. As for the input it will forward all input to
-   * the
-   * Slick {@link InputListener} that is implemented in this class.
-   *
-   * @param container the container used to display the game
-   * @param game the game this state is part of
-   * @throws IllegalStateException in case this function was called before
-   * @see SlickRenderDevice
-   * @see SlickSoundDevice
-   * @see SlickSlickInputSystem
-   */
-  protected final void initNifty(final GameContainer container, final StateBasedGame game) {
-    initNifty(container, game, new SlickSlickInputSystem(this));
-  }
+  protected abstract void prepareNifty(Nifty nifty, StateBasedGame game);
 
   @Override
   public final boolean isInputForwardingSupported() {
@@ -204,24 +251,24 @@ public abstract class NiftyOverlayGameState implements GameState, NiftyInputForw
   protected abstract void leaveState(GameContainer container, StateBasedGame game) throws SlickException;
 
   /**
-   * This function should be used to prepare the actual GUI and the controllers of the Nifty GUI. It is called right
-   * after the Nifty GUI got initialized.
-   *
-   * @param nifty the Nifty GUI that got initialized
-   * @param game the game this state is part of
-   */
-  protected abstract void prepareNifty(Nifty nifty, StateBasedGame game);
-
-  /**
    * Render the game.
    */
   @Override
   public final void render(
       final GameContainer container, final StateBasedGame game, final Graphics g) throws SlickException {
-    renderGame(container, game, g);
-
-    if (niftyGUI != null) {
-      niftyGUI.render(false);
+    if (niftyGUI == null) {
+      renderGame(container, game, g);
+    } else {
+      switch (renderOrder) {
+        case NiftyOverlay:
+          renderGame(container, game, g);
+          niftyGUI.render(false);
+          break;
+        case NiftyBackground:
+          niftyGUI.render(true);
+          renderGame(container, game, g);
+          break;
+      }
     }
   }
 
@@ -242,10 +289,19 @@ public abstract class NiftyOverlayGameState implements GameState, NiftyInputForw
   @Override
   public final void update(
       final GameContainer container, final StateBasedGame game, final int delta) throws SlickException {
-    updateGame(container, game, delta);
-
-    if (niftyGUI != null) {
-      niftyGUI.update();
+    if (niftyGUI == null) {
+      updateGame(container, game, delta);
+    } else {
+      switch (updateOrder) {
+        case NiftyLast:
+          updateGame(container, game, delta);
+          niftyGUI.update();
+          break;
+        case NiftyFirst:
+          niftyGUI.update();
+          updateGame(container, game, delta);
+          break;
+      }
     }
   }
 

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/NiftyOverlayGameState.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/NiftyOverlayGameState.java
@@ -76,13 +76,16 @@ public abstract class NiftyOverlayGameState implements GameState {
 
   /**
    * Initialize the game. This function is called during
-   * {@link #init(GameContainer)}. During this call its needed to initialize the
+   * {@link #init(GameContainer, StateBasedGame)}. During this call its needed to initialize the
    * Nifty GUI with own options by calling
-   * {@link #initNifty(GameContainer, SlickRenderDevice, SlickSoundDevice, TimeProvider)}
+   * {@link #initNifty(GameContainer, StateBasedGame, SlickRenderDevice, SlickSoundDevice, SlickInputSystem,
+   * TimeProvider)}
    * .
    * 
    * @param container
    *          the game container that displays the game
+   * @param game
+   *          the state based game this state is part of
    * @throws SlickException
    *           in case initializing the game goes wrong
    */
@@ -128,7 +131,7 @@ public abstract class NiftyOverlayGameState implements GameState {
 
   /**
    * Initialize the Nifty GUI for this game. This function will use the default
-   * {@link de.lessvoid.nifty.tools.TimeProvider}.
+   * {@link de.lessvoid.nifty.spi.time.TimeProvider}.
    * 
    * @param container
    *          the container used to display the game
@@ -154,7 +157,7 @@ public abstract class NiftyOverlayGameState implements GameState {
 
   /**
    * Initialize the Nifty GUI for this game. This function will use the default
-   * {@link de.lessvoid.nifty.tools.TimeProvider}. Also it will use the render
+   * {@link de.lessvoid.nifty.spi.time.TimeProvider}. Also it will use the render
    * and sound devices that are provided with this library.
    * @see de.lessvoid.nifty.slick2d.render.SlickRenderDevice
    * @see de.lessvoid.nifty.slick2d.sound.SlickSoundDevice
@@ -177,7 +180,7 @@ public abstract class NiftyOverlayGameState implements GameState {
 
   /**
    * Initialize the Nifty GUI for this game. This function will use the default
-   * {@link de.lessvoid.nifty.tools.TimeProvider}. Also it will use the render
+   * {@link de.lessvoid.nifty.spi.time.TimeProvider}. Also it will use the render
    * and sound devices that are provided with this library. As for the input it
    * will forward all input to the Slick {@link org.newdawn.slick.InputListener}
    * that is implemented in this class.
@@ -246,10 +249,12 @@ public abstract class NiftyOverlayGameState implements GameState {
 
   /**
    * This function is supposed to be used to render the game. It is called
-   * during the call of the {@link #render(GameContainer, Graphics)} function.
+   * during the call of the {@link #render(GameContainer, StateBasedGame, Graphics)} function.
    * 
    * @param container
    *          the container that displays the game
+   * @param game
+   *          the state based game this state is part of
    * @param g
    *          the graphics instance that is used to draw the game
    * @throws SlickException
@@ -272,10 +277,12 @@ public abstract class NiftyOverlayGameState implements GameState {
 
   /**
    * This function is supposed to be used to update the state of the game. It
-   * called during the call of the {@link #update(GameContainer, int)} function.
+   * called during the call of the {@link #update(GameContainer, StateBasedGame, int)} function.
    * 
    * @param container
    *          the container that displays the game
+   * @param game
+   *          the state based game this state is part of
    * @param delta
    *          the time since the last update
    * @throws SlickException

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/NiftyOverlayGameState.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/NiftyOverlayGameState.java
@@ -1,12 +1,5 @@
 package de.lessvoid.nifty.slick2d;
 
-import org.newdawn.slick.GameContainer;
-import org.newdawn.slick.Graphics;
-import org.newdawn.slick.Input;
-import org.newdawn.slick.SlickException;
-import org.newdawn.slick.state.GameState;
-import org.newdawn.slick.state.StateBasedGame;
-
 import de.lessvoid.nifty.Nifty;
 import de.lessvoid.nifty.slick2d.input.SlickInputSystem;
 import de.lessvoid.nifty.slick2d.input.SlickSlickInputSystem;
@@ -14,17 +7,20 @@ import de.lessvoid.nifty.slick2d.render.SlickRenderDevice;
 import de.lessvoid.nifty.slick2d.sound.SlickSoundDevice;
 import de.lessvoid.nifty.slick2d.time.LWJGLTimeProvider;
 import de.lessvoid.nifty.spi.time.TimeProvider;
+import org.newdawn.slick.*;
+import org.newdawn.slick.state.GameState;
+import org.newdawn.slick.state.StateBasedGame;
 
 public abstract class NiftyOverlayGameState implements GameState {
   /**
    * The input system that is used by this game state.
    */
-  private SlickInputSystem inputSystem;
+  private SlickInputSystem inSystem = null;
 
   /**
    * The one and only Nifty GUI.
    */
-  private Nifty niftyGUI;
+  private Nifty niftyGUI = null;
 
   /**
    * Enter the game state.
@@ -32,28 +28,25 @@ public abstract class NiftyOverlayGameState implements GameState {
   @Override
   public final void enter(final GameContainer container, final StateBasedGame game) throws SlickException {
     final Input input = container.getInput();
-    input.removeListener(inputSystem);
-    input.addListener(inputSystem);
+    input.removeListener(inSystem);
+    input.addListener(inSystem);
 
     enterState(container, game);
   }
 
   /**
-   * Enter the game state. This function is called during the default
-   * {@link #enter(GameContainer, StateBasedGame)} function call.
-   * 
-   * @param container
-   *          the container that displays the game
-   * @param game
-   *          the state based game this state is a part of
-   * @throws SlickException
-   *           in case entering the state fails
+   * Enter the game state. This function is called during the default {@link #enter(GameContainer, StateBasedGame)}
+   * function call.
+   *
+   * @param container the container that displays the game
+   * @param game the state based game this state is a part of
+   * @throws SlickException in case entering the state fails
    */
-  protected abstract void enterState(final GameContainer container, final StateBasedGame game) throws SlickException;
+  protected abstract void enterState(GameContainer container, StateBasedGame game) throws SlickException;
 
   /**
    * Get the instance of the NiftyGUI that is used to render this screen.
-   * 
+   *
    * @return the instance of the NiftyGUI
    */
   public final Nifty getNifty() {
@@ -75,42 +68,30 @@ public abstract class NiftyOverlayGameState implements GameState {
   }
 
   /**
-   * Initialize the game. This function is called during
-   * {@link #init(GameContainer, StateBasedGame)}. During this call its needed to initialize the
-   * Nifty GUI with own options by calling
-   * {@link #initNifty(GameContainer, StateBasedGame, SlickRenderDevice, SlickSoundDevice, SlickInputSystem,
-   * TimeProvider)}
-   * .
-   * 
-   * @param container
-   *          the game container that displays the game
-   * @param game
-   *          the state based game this state is part of
-   * @throws SlickException
-   *           in case initializing the game goes wrong
+   * Initialize the game. This function is called during {@link #init(GameContainer, StateBasedGame)}. During this call
+   * its needed to initialize the Nifty GUI with own options by calling {@link #initNifty(GameContainer,
+   * StateBasedGame,
+   * SlickRenderDevice, SlickSoundDevice, SlickInputSystem, TimeProvider)} .
+   *
+   * @param container the game container that displays the game
+   * @param game the state based game this state is part of
+   * @throws SlickException in case initializing the game goes wrong
    */
-  protected abstract void initGameAndGUI(final GameContainer container, StateBasedGame game) throws SlickException;
+  protected abstract void initGameAndGUI(GameContainer container, StateBasedGame game) throws SlickException;
 
   /**
    * Initialize the Nifty GUI for this game.
-   * 
-   * @param container
-   *          the container used to display the game
-   * @param game
-   *          the game this state is part of
-   * @param renderDevice
-   *          the render device that is supposed to be used to render the GUI
-   * @param soundDevice
-   *          the sound device that is supposed to be used
-   * @param inputSystem
-   *          the input system that is supposed to be used
-   * @param timeProvider
-   *          the time provider that is supposed to be used
-   * @throws IllegalStateException
-   *           in case this function was called before
+   *
+   * @param container the container used to display the game
+   * @param game the game this state is part of
+   * @param renderDevice the render device that is supposed to be used to render the GUI
+   * @param soundDevice the sound device that is supposed to be used
+   * @param inputSystem the input system that is supposed to be used
+   * @param timeProvider the time provider that is supposed to be used
+   * @throws IllegalStateException in case this function was called before
    */
   protected final void initNifty(
-      final GameContainer container,
+      @SuppressWarnings("TypeMayBeWeakened") final GameContainer container,
       final StateBasedGame game,
       final SlickRenderDevice renderDevice,
       final SlickSoundDevice soundDevice,
@@ -124,27 +105,20 @@ public abstract class NiftyOverlayGameState implements GameState {
 
     niftyGUI = new Nifty(renderDevice, soundDevice, inputSystem, timeProvider);
 
-    this.inputSystem = inputSystem;
+    inSystem = inputSystem;
 
     prepareNifty(niftyGUI, game);
   }
 
   /**
-   * Initialize the Nifty GUI for this game. This function will use the default
-   * {@link de.lessvoid.nifty.spi.time.TimeProvider}.
-   * 
-   * @param container
-   *          the container used to display the game
-   * @param game
-   *          the game this state is part of
-   * @param renderDevice
-   *          the render device that is supposed to be used to render the GUI
-   * @param soundDevice
-   *          the sound device that is supposed to be used
-   * @param inputSystem
-   *          the input system that is supposed to be used
-   * @throws IllegalStateException
-   *           in case this function was called before
+   * Initialize the Nifty GUI for this game. This function will use the default {@link TimeProvider}.
+   *
+   * @param container the container used to display the game
+   * @param game the game this state is part of
+   * @param renderDevice the render device that is supposed to be used to render the GUI
+   * @param soundDevice the sound device that is supposed to be used
+   * @param inputSystem the input system that is supposed to be used
+   * @throws IllegalStateException in case this function was called before
    */
   protected final void initNifty(
       final GameContainer container,
@@ -156,44 +130,33 @@ public abstract class NiftyOverlayGameState implements GameState {
   }
 
   /**
-   * Initialize the Nifty GUI for this game. This function will use the default
-   * {@link de.lessvoid.nifty.spi.time.TimeProvider}. Also it will use the render
-   * and sound devices that are provided with this library.
-   * @see de.lessvoid.nifty.slick2d.render.SlickRenderDevice
-   * @see de.lessvoid.nifty.slick2d.sound.SlickSoundDevice
-   * 
-   * @param container
-   *          the container used to display the game
-   * @param game
-   *          the game this state is part of
-   * @param inputSystem
-   *          the input system that is supposed to be used
-   * @throws IllegalStateException
-   *           in case this function was called before
+   * Initialize the Nifty GUI for this game. This function will use the default {@link TimeProvider}. Also it will use
+   * the render and sound devices that are provided with this library.
+   *
+   * @param container the container used to display the game
+   * @param game the game this state is part of
+   * @param inputSystem the input system that is supposed to be used
+   * @throws IllegalStateException in case this function was called before
+   * @see SlickRenderDevice
+   * @see SlickSoundDevice
    */
   protected final void initNifty(
-      final GameContainer container,
-      final StateBasedGame game,
-      final SlickInputSystem inputSystem) {
+      final GameContainer container, final StateBasedGame game, final SlickInputSystem inputSystem) {
     initNifty(container, game, new SlickRenderDevice(container), new SlickSoundDevice(), inputSystem);
   }
 
   /**
-   * Initialize the Nifty GUI for this game. This function will use the default
-   * {@link de.lessvoid.nifty.spi.time.TimeProvider}. Also it will use the render
-   * and sound devices that are provided with this library. As for the input it
-   * will forward all input to the Slick {@link org.newdawn.slick.InputListener}
-   * that is implemented in this class.
-   * 
-   * @param container
-   *          the container used to display the game
-   * @param game
-   *          the game this state is part of
-   * @throws IllegalStateException
-   *           in case this function was called before
-   * @see de.lessvoid.nifty.slick2d.render.SlickRenderDevice
-   * @see de.lessvoid.nifty.slick2d.sound.SlickSoundDevice
-   * @see de.lessvoid.nifty.slick2d.input.SlickSlickInputSystem
+   * Initialize the Nifty GUI for this game. This function will use the default {@link TimeProvider}. Also it will use
+   * the render and sound devices that are provided with this library. As for the input it will forward all input to
+   * the
+   * Slick {@link InputListener} that is implemented in this class.
+   *
+   * @param container the container used to display the game
+   * @param game the game this state is part of
+   * @throws IllegalStateException in case this function was called before
+   * @see SlickRenderDevice
+   * @see SlickSoundDevice
+   * @see SlickSlickInputSystem
    */
   protected final void initNifty(final GameContainer container, final StateBasedGame game) {
     initNifty(container, game, new SlickSlickInputSystem(this));
@@ -205,32 +168,27 @@ public abstract class NiftyOverlayGameState implements GameState {
   @Override
   public final void leave(final GameContainer container, final StateBasedGame game) throws SlickException {
     final Input input = container.getInput();
-    input.removeListener(inputSystem);
+    input.removeListener(inSystem);
 
     leaveState(container, game);
   }
 
   /**
-   * Leave the game state. This function is called during the default
-   * {@link #leave(GameContainer, StateBasedGame)} function call.
-   * 
-   * @param container
-   *          the container that displays the game
-   * @param game
-   *          the state based game this state is a part of
-   * @throws SlickException
-   *           in case entering the state fails
+   * Leave the game state. This function is called during the default {@link #leave(GameContainer, StateBasedGame)}
+   * function call.
+   *
+   * @param container the container that displays the game
+   * @param game the state based game this state is a part of
+   * @throws SlickException in case entering the state fails
    */
-  protected abstract void leaveState(final GameContainer container, final StateBasedGame game) throws SlickException;
+  protected abstract void leaveState(GameContainer container, StateBasedGame game) throws SlickException;
 
   /**
-   * This function should be used to prepare the actual GUI and the controllers
-   * of the Nifty GUI. It is called right after the Nifty GUI got initialized.
-   * 
-   * @param nifty
-   *          the Nifty GUI that got initialized
-   * @param game
-   *          the game this state is part of
+   * This function should be used to prepare the actual GUI and the controllers of the Nifty GUI. It is called right
+   * after the Nifty GUI got initialized.
+   *
+   * @param nifty the Nifty GUI that got initialized
+   * @param game the game this state is part of
    */
   protected abstract void prepareNifty(Nifty nifty, StateBasedGame game);
 
@@ -238,8 +196,8 @@ public abstract class NiftyOverlayGameState implements GameState {
    * Render the game.
    */
   @Override
-  public final void render(final GameContainer container, final StateBasedGame game, final Graphics g)
-      throws SlickException {
+  public final void render(
+      final GameContainer container, final StateBasedGame game, final Graphics g) throws SlickException {
     renderGame(container, game, g);
 
     if (niftyGUI != null) {
@@ -248,17 +206,13 @@ public abstract class NiftyOverlayGameState implements GameState {
   }
 
   /**
-   * This function is supposed to be used to render the game. It is called
-   * during the call of the {@link #render(GameContainer, StateBasedGame, Graphics)} function.
-   * 
-   * @param container
-   *          the container that displays the game
-   * @param game
-   *          the state based game this state is part of
-   * @param g
-   *          the graphics instance that is used to draw the game
-   * @throws SlickException
-   *           in case anything goes wrong during the rendering
+   * This function is supposed to be used to render the game. It is called during the call of the {@link
+   * #render(GameContainer, StateBasedGame, Graphics)} function.
+   *
+   * @param container the container that displays the game
+   * @param game the state based game this state is part of
+   * @param g the graphics instance that is used to draw the game
+   * @throws SlickException in case anything goes wrong during the rendering
    */
   protected abstract void renderGame(GameContainer container, StateBasedGame game, Graphics g) throws SlickException;
 
@@ -266,8 +220,8 @@ public abstract class NiftyOverlayGameState implements GameState {
    * Update the game.
    */
   @Override
-  public final void update(final GameContainer container, final StateBasedGame game, final int delta)
-      throws SlickException {
+  public final void update(
+      final GameContainer container, final StateBasedGame game, final int delta) throws SlickException {
     updateGame(container, game, delta);
 
     if (niftyGUI != null) {
@@ -276,17 +230,13 @@ public abstract class NiftyOverlayGameState implements GameState {
   }
 
   /**
-   * This function is supposed to be used to update the state of the game. It
-   * called during the call of the {@link #update(GameContainer, StateBasedGame, int)} function.
-   * 
-   * @param container
-   *          the container that displays the game
-   * @param game
-   *          the state based game this state is part of
-   * @param delta
-   *          the time since the last update
-   * @throws SlickException
-   *           in case anything goes wrong during the update
+   * This function is supposed to be used to update the state of the game. It called during the call of the {@link
+   * #update(GameContainer, StateBasedGame, int)} function.
+   *
+   * @param container the container that displays the game
+   * @param game the state based game this state is part of
+   * @param delta the time since the last update
+   * @throws SlickException in case anything goes wrong during the update
    */
   protected abstract void updateGame(GameContainer container, StateBasedGame game, int delta) throws SlickException;
 }

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/NiftyRenderOrder.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/NiftyRenderOrder.java
@@ -1,0 +1,20 @@
+package de.lessvoid.nifty.slick2d;
+
+/**
+ * This enumerator contains the possible settings for the render order of the Nifty-GUI and the game in the overlay
+ * game
+ * and game state implementations.
+ *
+ * @author Marting Karing &lt;nitram@illarion.org&gt;
+ */
+public enum NiftyRenderOrder {
+  /**
+   * Using this enumerator value the game will be rendered first, followed by the Nifty-GUI.
+   */
+  NiftyOverlay,
+
+  /**
+   * Using this enumerator value the Nifty-GUI will be rendered first, followed by the game.
+   */
+  NiftyBackground
+}

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/NiftyUpdateOrder.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/NiftyUpdateOrder.java
@@ -1,0 +1,20 @@
+package de.lessvoid.nifty.slick2d;
+
+/**
+ * This enumerator contains the possible settings for the update order of the Nifty-GUI and the game in the overlay
+ * game
+ * and game state implementations.
+ *
+ * @author Marting Karing &lt;nitram@illarion.org&gt;
+ */
+public enum NiftyUpdateOrder {
+  /**
+   * Using this enumerator value the game will be updated first, followed by the Nifty-GUI.
+   */
+  NiftyLast,
+
+  /**
+   * Using this enumerator value the Nifty-GUI will be updated first, followed by the game.
+   */
+  NiftyFirst
+}

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/input/AbstractSlickInputSystem.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/input/AbstractSlickInputSystem.java
@@ -181,7 +181,7 @@ public abstract class AbstractSlickInputSystem extends InputAdapter implements S
     if ((forwardMode == ForwardingMode.all) || (mode == ForwardingMode.none) || (mode == forwardMode)) {
       return;
     }
-    
+
     if (mode == ForwardingMode.all) {
       forwardMode = ForwardingMode.all;
     }

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/input/AbstractSlickInputSystem.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/input/AbstractSlickInputSystem.java
@@ -128,11 +128,8 @@ public abstract class AbstractSlickInputSystem extends InputAdapter implements S
    *         {@link org.newdawn.slick.Input} instance was set properly, else
    *         <code>false</code>
    */
-  private final boolean isControlDown() {
-    if (input == null) {
-      return false;
-    }
-    return input.isKeyDown(Input.KEY_LCONTROL) || input.isKeyDown(Input.KEY_RCONTROL);
+  private boolean isControlDown() {
+      return input != null && (input.isKeyDown(Input.KEY_LCONTROL) || input.isKeyDown(Input.KEY_RCONTROL));
   }
 
   /**
@@ -145,11 +142,8 @@ public abstract class AbstractSlickInputSystem extends InputAdapter implements S
    *         {@link org.newdawn.slick.Input} instance was set properly, else
    *         <code>false</code>
    */
-  private final boolean isShiftDown() {
-    if (input == null) {
-      return false;
-    }
-    return input.isKeyDown(Input.KEY_LSHIFT) || input.isKeyDown(Input.KEY_RSHIFT);
+  private boolean isShiftDown() {
+      return input != null && (input.isKeyDown(Input.KEY_LSHIFT) || input.isKeyDown(Input.KEY_RSHIFT));
   }
 
   /**
@@ -180,17 +174,17 @@ public abstract class AbstractSlickInputSystem extends InputAdapter implements S
    * {@inheritDoc}
    */
   @Override
-  public final void mouseDragged(final int oldx, final int oldy, final int newx, final int newy) {
-    final int lastButton = buttonPressedStack.get(buttonPressedStack.size() - 1).intValue();
-    inputEventList.add(new MouseEventDragged(lastButton, oldx, oldy, newx, newy));
+  public final void mouseDragged(final int oldX, final int oldY, final int newX, final int newY) {
+    final int lastButton = buttonPressedStack.get(buttonPressedStack.size() - 1);
+    inputEventList.add(new MouseEventDragged(lastButton, oldX, oldY, newX, newY));
   }
 
   /**
    * {@inheritDoc}
    */
   @Override
-  public final void mouseMoved(final int oldx, final int oldy, final int newx, final int newy) {
-    inputEventList.add(new MouseEventMoved(oldx, oldy, newx, newy));
+  public final void mouseMoved(final int oldX, final int oldY, final int newX, final int newY) {
+    inputEventList.add(new MouseEventMoved(oldX, oldY, newX, newY));
   }
 
   /**
@@ -199,7 +193,7 @@ public abstract class AbstractSlickInputSystem extends InputAdapter implements S
   @Override
   public final void mousePressed(final int button, final int x, final int y) {
     inputEventList.add(new MouseEventPressed(x, y, button));
-    buttonPressedStack.add(Integer.valueOf(button));
+    buttonPressedStack.add(button);
   }
 
   /**

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/input/AbstractSlickInputSystem.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/input/AbstractSlickInputSystem.java
@@ -1,32 +1,35 @@
 package de.lessvoid.nifty.slick2d.input;
 
+import org.lwjgl.input.Mouse;
+
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 
-import org.lwjgl.input.Mouse;
+import de.lessvoid.nifty.NiftyInputConsumer;
+import de.lessvoid.nifty.slick2d.input.events.*;
+import de.lessvoid.nifty.tools.resourceloader.NiftyResourceLoader;
 import org.newdawn.slick.Input;
 import org.newdawn.slick.util.InputAdapter;
 
-import de.lessvoid.nifty.NiftyInputConsumer;
-import de.lessvoid.nifty.slick2d.input.events.InputEvent;
-import de.lessvoid.nifty.slick2d.input.events.KeyboardEventPressed;
-import de.lessvoid.nifty.slick2d.input.events.KeyboardEventReleased;
-import de.lessvoid.nifty.slick2d.input.events.MouseEventClicked;
-import de.lessvoid.nifty.slick2d.input.events.MouseEventDragged;
-import de.lessvoid.nifty.slick2d.input.events.MouseEventMoved;
-import de.lessvoid.nifty.slick2d.input.events.MouseEventPressed;
-import de.lessvoid.nifty.slick2d.input.events.MouseEventReleased;
-import de.lessvoid.nifty.slick2d.input.events.MouseEventWheelMoved;
-import de.lessvoid.nifty.tools.resourceloader.NiftyResourceLoader;
-
 /**
- * This is the abstract Input System implementation to connect the Input of
- * Slick and Nifty.
- * 
+ * This is the abstract Input System implementation to connect the Input of Slick and Nifty.
+ *
  * @author Martin Karing &lt;nitram@illarion.org&gt;
  */
+@SuppressWarnings("AbstractClassExtendsConcreteClass")
 public abstract class AbstractSlickInputSystem extends InputAdapter implements SlickInputSystem {
+  /**
+   * This constants holds the initial size of the storage list that holds the received input events.
+   */
+  private static final int INPUT_EVENT_BUFFER_INIT_SIZE = 20;
+
+  /**
+   * The delta value is divided by this value in order to give Nifty nice values for the mouse wheel movement. Reducing
+   * this value will increase the speed the mouse wheel moves for Nifty.
+   */
+  private static final int WHEEL_DELTA_CORRECTION = 120;
+
   /**
    * The list of buttons that got pressed and are still pressed.
    */
@@ -35,7 +38,7 @@ public abstract class AbstractSlickInputSystem extends InputAdapter implements S
   /**
    * The input system that feeds this input system with data.
    */
-  private Input input;
+  private Input input = null;
 
   /**
    * The list of input events that was registered but yet not processed.
@@ -51,31 +54,26 @@ public abstract class AbstractSlickInputSystem extends InputAdapter implements S
    * Prepare all required instances to work with this class.
    */
   protected AbstractSlickInputSystem() {
-    super();
-    inputEventList = new ArrayList<InputEvent>();
+    inputEventList = new ArrayList<InputEvent>(INPUT_EVENT_BUFFER_INIT_SIZE);
     buttonPressedStack = new LinkedList<Integer>();
     inputState = new InputState();
   }
 
   /**
-   * This is called by Nifty and used to poll the input events. In case the
-   * event is not handled by the NiftyGUI is send to the additional input event
-   * handler that is implemented by the {@link #handleInputEvent(InputEvent)}
-   * function.
-   * 
-   * @param inputEventConsumer
-   *          the input event consumer that is provided by Nifty, it will
-   *          receive all events first
+   * This is called by Nifty and used to poll the input events. In case the event is not handled by the NiftyGUI is
+   * send
+   * to the additional input event handler that is implemented by the {@link #handleInputEvent(InputEvent)} function.
+   *
+   * @param inputEventConsumer the input event consumer that is provided by Nifty, it will receive all events first
    */
   @Override
   public final void forwardEvents(final NiftyInputConsumer inputEventConsumer) {
-    InputEvent currentEvent;
     while (!inputEventList.isEmpty()) {
-      currentEvent = inputEventList.remove(0);
+      final InputEvent currentEvent = inputEventList.remove(0);
       if (!currentEvent.executeEvent(inputState)) {
         continue;
       }
-      
+
       if (currentEvent.sendToNifty(inputEventConsumer)) {
         currentEvent.updateState(inputState, true);
       } else {
@@ -86,119 +84,66 @@ public abstract class AbstractSlickInputSystem extends InputAdapter implements S
   }
 
   /**
-   * This function is called in case a input event was not handled by the Nifty
-   * event consumer of the Nifty GUI.
-   * 
-   * @param event
-   *          the event that needs to be handled
+   * This function is called in case a input event was not handled by the Nifty event consumer of the Nifty GUI.
+   *
+   * @param event the event that needs to be handled
    */
   protected abstract void handleInputEvent(InputEvent event);
 
   /**
-   * {@inheritDoc}
-   */
-  @Override
-  public final void inputEnded() {
-    // nothing to do once all input events were send
-  }
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  public final void inputStarted() {
-    // nothing to do when the input starts
-  }
-
-  /**
-   * {@inheritDoc}
-   */
-  @Override
-  public final boolean isAcceptingInput() {
-    return true;
-  }
-
-  /**
-   * Check if the control key is pressed down. This function requires the
-   * {@link org.newdawn.slick.Input} instance that is used by Slick to be sent
-   * in order to work properly. Setting this instance is done by calling
-   * {@link #setInput(Input)}.
-   * 
-   * @return <code>true</code> in case one of the control keys is done and the
-   *         {@link org.newdawn.slick.Input} instance was set properly, else
-   *         <code>false</code>
+   * Check if the control key is pressed down. This function requires the {@link Input} instance that is used by Slick
+   * to be sent in order to work properly. Setting this instance is done by calling {@link #setInput(Input)}.
+   *
+   * @return {@code true} in case one of the control keys is done and the {@link Input} instance was set properly, else
+   *         {@code false}
    */
   private boolean isControlDown() {
-      return input != null && (input.isKeyDown(Input.KEY_LCONTROL) || input.isKeyDown(Input.KEY_RCONTROL));
+    return (input != null) && (input.isKeyDown(Input.KEY_LCONTROL) || input.isKeyDown(Input.KEY_RCONTROL));
   }
 
   /**
-   * Check if the shift key is pressed down. This function requires the
-   * {@link org.newdawn.slick.Input} instance that is used by Slick to be sent
-   * in order to work properly. Setting this instance is done by calling
-   * {@link #setInput(Input)}.
-   * 
-   * @return <code>true</code> in case one of the shift keys is done and the
-   *         {@link org.newdawn.slick.Input} instance was set properly, else
-   *         <code>false</code>
+   * Check if the shift key is pressed down. This function requires the {@link Input} instance that is used by Slick to
+   * be sent in order to work properly. Setting this instance is done by calling {@link #setInput(Input)}.
+   *
+   * @return {@code true} in case one of the shift keys is done and the {@link Input} instance was set properly, else
+   *         {@code false}
    */
   private boolean isShiftDown() {
-      return input != null && (input.isKeyDown(Input.KEY_LSHIFT) || input.isKeyDown(Input.KEY_RSHIFT));
+    return (input != null) && (input.isKeyDown(Input.KEY_LSHIFT) || input.isKeyDown(Input.KEY_RSHIFT));
   }
 
-  /**
-   * {@inheritDoc}
-   */
   @Override
   public final void keyPressed(final int key, final char c) {
     inputEventList.add(new KeyboardEventPressed(key, c, isShiftDown(), isControlDown()));
   }
 
-  /**
-   * {@inheritDoc}
-   */
   @Override
   public final void keyReleased(final int key, final char c) {
     inputEventList.add(new KeyboardEventReleased(key, c, isShiftDown(), isControlDown()));
   }
 
-  /**
-   * {@inheritDoc}
-   */
   @Override
   public final void mouseClicked(final int button, final int x, final int y, final int clickCount) {
     inputEventList.add(new MouseEventClicked(x, y, button, clickCount));
   }
 
-  /**
-   * {@inheritDoc}
-   */
   @Override
   public final void mouseDragged(final int oldX, final int oldY, final int newX, final int newY) {
     final int lastButton = buttonPressedStack.get(buttonPressedStack.size() - 1);
     inputEventList.add(new MouseEventDragged(lastButton, oldX, oldY, newX, newY));
   }
 
-  /**
-   * {@inheritDoc}
-   */
   @Override
   public final void mouseMoved(final int oldX, final int oldY, final int newX, final int newY) {
     inputEventList.add(new MouseEventMoved(oldX, oldY, newX, newY));
   }
 
-  /**
-   * {@inheritDoc}
-   */
   @Override
   public final void mousePressed(final int button, final int x, final int y) {
     inputEventList.add(new MouseEventPressed(x, y, button));
     buttonPressedStack.add(button);
   }
 
-  /**
-   * {@inheritDoc}
-   */
   @Override
   public final void mouseReleased(final int button, final int x, final int y) {
     inputEventList.add(new MouseEventReleased(x, y, button));
@@ -206,52 +151,42 @@ public abstract class AbstractSlickInputSystem extends InputAdapter implements S
   }
 
   /**
-   * {@inheritDoc}. This function requires the {@link org.newdawn.slick.Input}
-   * instance that is used by Slick to be sent in order to work properly.
-   * Setting this instance is done by calling {@link #setInput(Input)}.
-   * 
-   * @throws IllegalStateException
-   *           in case the {@link org.newdawn.slick.Input} was not set
+   * {@inheritDoc}. This function requires the {@link Input} instance that is used by Slick to be sent in order to work
+   * properly. Setting this instance is done by calling {@link #setInput(Input)}.
+   *
+   * @throws IllegalStateException in case the {@link Input} was not set
    */
   @Override
   public final void mouseWheelMoved(final int change) {
     if (input == null) {
       throw new IllegalStateException("Can't generate mouse wheel events without a reference to the Input");
     }
-    inputEventList.add(new MouseEventWheelMoved(input.getMouseX(), input.getMouseY(), change / 120));
+    inputEventList.add(new MouseEventWheelMoved(input.getMouseX(), input.getMouseY(),
+        change / WHEEL_DELTA_CORRECTION));
   }
 
   /**
-   * Set the {@link org.newdawn.slick.Input} instance that is used by Slick to
-   * handle the user input. Some functions of this class require this instance
-   * to work properly. Calling this function will also make sure that the
-   * {@link org.newdawn.slick.Input} instance is configured properly so the GUI
-   * works as expected.
-   * 
-   * @param input
-   *          the {@link org.newdawn.slick.Input} instance
+   * Set the {@link Input} instance that is used by Slick to handle the user input. Some functions of this class
+   * require
+   * this instance to work properly. Calling this function will also make sure that the {@link Input} instance is
+   * configured properly so the GUI works as expected.
+   *
+   * @param newInput the {@link Input} instance
    * @see #mouseWheelMoved(int)
    * @see #isControlDown()
    * @see #isShiftDown()
-   * 
    */
   @Override
-  public final void setInput(final Input input) {
-    this.input = input;
+  public final void setInput(final Input newInput) {
+    input = newInput;
     input.enableKeyRepeat();
   }
 
-  /**
-   * {@inheritDoc}
-   */
   @Override
   public final void setMousePosition(final int x, final int y) {
     Mouse.setCursorPosition(x, y);
   }
-  
-  /**
-   * {@inheritDoc}
-   */
+
   @Override
   public void setResourceLoader(final NiftyResourceLoader resourceLoader) {
     // no use for the resource loader

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/input/ForwardingInputSystem.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/input/ForwardingInputSystem.java
@@ -1,0 +1,54 @@
+package de.lessvoid.nifty.slick2d.input;
+
+/**
+ * This interface is used in Input Systems that are able to forward events not handled by Nifty-GUI to other input
+ * listeners.
+ *
+ * @author Martin Karing &lt;nitram@illarion.org&gt;
+ */
+public interface ForwardingInputSystem {
+  /**
+   * Request exclusive mouse access. This causes that mouse events are not send to the Nifty-GUI but to the underlying
+   * game directly.
+   * <p />
+   * <b>Important:</b> Be sure to disable this mode again as it renders the Nifty-GUI non-functional. While enabled
+   * its impossible to interact with the GUI elements by mouse.
+   */
+  void requestExclusiveMouse();
+
+  /**
+   * Request exclusive keyboard access. This causes that keyboard events are not send to the Nifty-GUI but to the
+   * underlying game directly.
+   * <p />
+   * <b>Important:</b> Be sure to disable this mode again as it renders the Nifty-GUI non-functional. While enabled
+   * its impossible to interact with the GUI elements by keyboard.
+   */
+  void requestExclusiveKeyboard();
+
+  /**
+   * Request exclusive input access. This causes that mouse and keyboard events are not send to the Nifty-GUI but to
+   * the underlying game directly.
+   * <p />
+   * <b>Important:</b> Be sure to disable this mode again as it renders the Nifty-GUI non-functional. While enabled
+   * its impossible to interact with the GUI elements at all.
+   */
+  void requestExclusiveInput();
+
+  /**
+   * This command releases the exclusive access on the mouse events. After this command is called, the input events are
+   * send to the Nifty-GUI again.
+   */
+  void releaseExclusiveMouse();
+
+  /**
+   * This command releases the exclusive access on the keyboard events. After this command is called, the input events
+   * are send to the Nifty-GUI again.
+   */
+  void releaseExclusiveKeyboard();
+
+  /**
+   * Release all exclusive access requests. This resets in input system to its normal operation mode. All input events
+   * are first send to the Nifty-GUI and second to an additional listener if any.
+   */
+  void releaseExclusiveInput();
+}

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/input/ForwardingInputSystem.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/input/ForwardingInputSystem.java
@@ -10,27 +10,28 @@ public interface ForwardingInputSystem {
   /**
    * Request exclusive mouse access. This causes that mouse events are not send to the Nifty-GUI but to the underlying
    * game directly.
-   * <p />
-   * <b>Important:</b> Be sure to disable this mode again as it renders the Nifty-GUI non-functional. While enabled
-   * its impossible to interact with the GUI elements by mouse.
+   * <p/>
+   * <b>Important:</b> Be sure to disable this mode again as it renders the Nifty-GUI non-functional. While enabled its
+   * impossible to interact with the GUI elements by mouse.
    */
   void requestExclusiveMouse();
 
   /**
    * Request exclusive keyboard access. This causes that keyboard events are not send to the Nifty-GUI but to the
    * underlying game directly.
-   * <p />
-   * <b>Important:</b> Be sure to disable this mode again as it renders the Nifty-GUI non-functional. While enabled
-   * its impossible to interact with the GUI elements by keyboard.
+   * <p/>
+   * <b>Important:</b> Be sure to disable this mode again as it renders the Nifty-GUI non-functional. While enabled its
+   * impossible to interact with the GUI elements by keyboard.
    */
   void requestExclusiveKeyboard();
 
   /**
    * Request exclusive input access. This causes that mouse and keyboard events are not send to the Nifty-GUI but to
-   * the underlying game directly.
-   * <p />
-   * <b>Important:</b> Be sure to disable this mode again as it renders the Nifty-GUI non-functional. While enabled
-   * its impossible to interact with the GUI elements at all.
+   * the
+   * underlying game directly.
+   * <p/>
+   * <b>Important:</b> Be sure to disable this mode again as it renders the Nifty-GUI non-functional. While enabled its
+   * impossible to interact with the GUI elements at all.
    */
   void requestExclusiveInput();
 

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/input/ForwardingMode.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/input/ForwardingMode.java
@@ -1,0 +1,30 @@
+package de.lessvoid.nifty.slick2d.input;
+
+/**
+ * This enumerator stores the forwarding modes the input systems are supporting.
+ *
+ * @author Martin Karing &lt;nitram@illarion.org&gt;
+ */
+public enum ForwardingMode {
+  /**
+   * Normal mode. Relay all events first to the Nifty-GUI and in case they are not handled by the GUI, forward them to
+   * the forwarding listener.
+   */
+  none,
+
+  /**
+   * Forward all mouse events directly to the second listeners and do not send them to the Nifty-GUI.
+   */
+  mouse,
+
+  /**
+   * Forward all keyboard events directly to the second listeners and do not send them to the Nifty-GUI.
+   */
+  keyboard,
+
+  /**
+   * Forward all input events (mouse and keyboard) directly to the second listeners and do not send them to the
+   * Nifty-GUI.
+   */
+  all
+}

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/input/InputState.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/input/InputState.java
@@ -1,22 +1,20 @@
 package de.lessvoid.nifty.slick2d.input;
 
 /**
- * This small class is able to store some states that are needed for the
- * communication between different input events.
- * 
+ * This small class is able to store some states that are needed for the communication between different input events.
+ *
  * @author Martin Karing &lt;nitram@illarion.org&gt;
  */
 public final class InputState {
   /**
-   * In case this state is switched to <code>true</code> the next click events
-   * needs to be consumed entirely.
+   * In case this state is switched to {@code true} the next click events needs to be consumed entirely.
    */
-  private boolean consumeNextClick = false;
+  private boolean consumeNextClick;
 
   /**
    * Check if the next click event needs to be consumed.
-   * 
-   * @return <code>true</code> if the next click event needs to be consumed
+   *
+   * @return {@code true} if the next click event needs to be consumed
    */
   public boolean isConsumeNextClick() {
     return consumeNextClick;
@@ -24,12 +22,10 @@ public final class InputState {
 
   /**
    * Set the consume next input event flag.
-   * 
-   * @param consumeNextClick
-   *          <code>true</code> in case the next input event is supposed to be
-   *          consumed
+   *
+   * @param value {@code true} in case the next input event is supposed to be consumed
    */
-  public void setConsumeNextClick(final boolean consumeNextClick) {
-    this.consumeNextClick = consumeNextClick;
+  public void setConsumeNextClick(final boolean value) {
+    consumeNextClick = value;
   }
 }

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/input/NiftySlickInputSystem.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/input/NiftySlickInputSystem.java
@@ -5,27 +5,22 @@ import de.lessvoid.nifty.slick2d.input.events.InputEvent;
 
 /**
  * This is the input system that forwards all events to a Nifty input consumer.
- * 
+ *
  * @author Martin Karing &lt;nitram@illarion.org&gt;
  */
 public final class NiftySlickInputSystem extends AbstractSlickInputSystem {
   /**
-   * The consumer that is supposed to receive any input events that are not used
-   * by the Nifty GUI.
+   * The consumer that is supposed to receive any input events that are not used by the Nifty GUI.
    */
   private final NiftyInputConsumer consumer;
 
   /**
-   * Create a input system that forwards all events to a Nifty-style input
-   * consumer.
-   * 
-   * @param targetConsumer
-   *          the consumer that is supposed to receive any unused input events
-   * @throws IllegalArgumentException
-   *           in case the targetConsumer parameter is <code>null</code>
+   * Create a input system that forwards all events to a Nifty-style input consumer.
+   *
+   * @param targetConsumer the consumer that is supposed to receive any unused input events
+   * @throws IllegalArgumentException in case the targetConsumer parameter is {@code null}
    */
   public NiftySlickInputSystem(final NiftyInputConsumer targetConsumer) {
-    super();
     if (targetConsumer == null) {
       throw new IllegalArgumentException("The target consumer must not be NULL.");
     }

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/input/NiftySlickInputSystem.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/input/NiftySlickInputSystem.java
@@ -8,7 +8,7 @@ import de.lessvoid.nifty.slick2d.input.events.InputEvent;
  *
  * @author Martin Karing &lt;nitram@illarion.org&gt;
  */
-public final class NiftySlickInputSystem extends AbstractSlickInputSystem {
+public final class NiftySlickInputSystem extends AbstractSlickInputSystem implements ForwardingInputSystem{
   /**
    * The consumer that is supposed to receive any input events that are not used by the Nifty GUI.
    */
@@ -33,5 +33,35 @@ public final class NiftySlickInputSystem extends AbstractSlickInputSystem {
   @Override
   protected void handleInputEvent(final InputEvent event) {
     event.sendToNifty(consumer);
+  }
+
+  @Override
+  public void requestExclusiveMouse() {
+    enableForwardingMode(ForwardingMode.mouse);
+  }
+
+  @Override
+  public void requestExclusiveKeyboard() {
+    enableForwardingMode(ForwardingMode.keyboard);
+  }
+
+  @Override
+  public void requestExclusiveInput() {
+    enableForwardingMode(ForwardingMode.all);
+  }
+
+  @Override
+  public void releaseExclusiveMouse() {
+    disableForwardingMode(ForwardingMode.mouse);
+  }
+
+  @Override
+  public void releaseExclusiveKeyboard() {
+    disableForwardingMode(ForwardingMode.keyboard);
+  }
+
+  @Override
+  public void releaseExclusiveInput() {
+    disableForwardingMode(ForwardingMode.all);
   }
 }

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/input/NiftySlickInputSystem.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/input/NiftySlickInputSystem.java
@@ -8,7 +8,7 @@ import de.lessvoid.nifty.slick2d.input.events.InputEvent;
  *
  * @author Martin Karing &lt;nitram@illarion.org&gt;
  */
-public final class NiftySlickInputSystem extends AbstractSlickInputSystem implements ForwardingInputSystem{
+public final class NiftySlickInputSystem extends AbstractSlickInputSystem implements ForwardingInputSystem {
   /**
    * The consumer that is supposed to receive any input events that are not used by the Nifty GUI.
    */

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/input/PlainSlickInputSystem.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/input/PlainSlickInputSystem.java
@@ -3,16 +3,14 @@ package de.lessvoid.nifty.slick2d.input;
 import de.lessvoid.nifty.slick2d.input.events.InputEvent;
 
 /**
- * This version of the input system is only usable in case all input is meant to
- * be used in the Nifty GUI. All input events Nifty does not use will be
- * discarded.
- * 
+ * This version of the input system is only usable in case all input is meant to be used in the Nifty GUI. All input
+ * events Nifty does not use will be discarded.
+ *
  * @author Martin Karing &lt;nitram@illarion.org&gt;
  */
 public final class PlainSlickInputSystem extends AbstractSlickInputSystem {
   /**
-   * All input events not handled by the Nifty GUI end up here and get
-   * discarded.
+   * All input events not handled by the Nifty GUI end up here and get discarded.
    */
   @Override
   protected void handleInputEvent(final InputEvent event) {

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/input/SlickInputSystem.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/input/SlickInputSystem.java
@@ -1,14 +1,13 @@
 package de.lessvoid.nifty.slick2d.input;
 
+import de.lessvoid.nifty.spi.input.InputSystem;
 import org.newdawn.slick.InputListener;
 
-import de.lessvoid.nifty.spi.input.InputSystem;
-
 /**
- * This interface merges the Nifty and the Slick Input interfaces as needed so
- * the implementing classes are able to work properly with the Nifty-Slick
- * binding.
- * 
+ * This interface merges the Nifty and the Slick Input interfaces as needed so the implementing classes are able to
+ * work
+ * properly with the Nifty-Slick binding.
+ *
  * @author Martin Karing &lt;nitram@illarion.org&gt;
  */
 public interface SlickInputSystem extends InputSystem, InputListener {

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/input/SlickSlickInputSystem.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/input/SlickSlickInputSystem.java
@@ -9,7 +9,7 @@ import org.newdawn.slick.InputListener;
  *
  * @author Martin Karing &lt;nitram@illarion.org&gt;
  */
-public final class SlickSlickInputSystem extends AbstractSlickInputSystem {
+public final class SlickSlickInputSystem extends AbstractSlickInputSystem implements ForwardingInputSystem {
   /**
    * The input listener that will receive any events the NiftyGUI does not use.
    */
@@ -34,5 +34,35 @@ public final class SlickSlickInputSystem extends AbstractSlickInputSystem {
   @Override
   protected void handleInputEvent(final InputEvent event) {
     event.sendToSlick(listener);
+  }
+
+  @Override
+  public void requestExclusiveMouse() {
+    enableForwardingMode(ForwardingMode.mouse);
+  }
+
+  @Override
+  public void requestExclusiveKeyboard() {
+    enableForwardingMode(ForwardingMode.keyboard);
+  }
+
+  @Override
+  public void requestExclusiveInput() {
+    enableForwardingMode(ForwardingMode.all);
+  }
+
+  @Override
+  public void releaseExclusiveMouse() {
+    disableForwardingMode(ForwardingMode.mouse);
+  }
+
+  @Override
+  public void releaseExclusiveKeyboard() {
+    disableForwardingMode(ForwardingMode.keyboard);
+  }
+
+  @Override
+  public void releaseExclusiveInput() {
+    disableForwardingMode(ForwardingMode.all);
   }
 }

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/input/SlickSlickInputSystem.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/input/SlickSlickInputSystem.java
@@ -1,13 +1,12 @@
 package de.lessvoid.nifty.slick2d.input;
 
+import de.lessvoid.nifty.slick2d.input.events.InputEvent;
 import org.newdawn.slick.InputListener;
 
-import de.lessvoid.nifty.slick2d.input.events.InputEvent;
-
 /**
- * This is the input system that forwards all events to a slick listener. Also
- * this input system is so slick, writing slick once is not even enough.
- * 
+ * This is the input system that forwards all events to a slick listener. Also this input system is so slick, writing
+ * slick once is not even enough.
+ *
  * @author Martin Karing &lt;nitram@illarion.org&gt;
  */
 public final class SlickSlickInputSystem extends AbstractSlickInputSystem {
@@ -17,16 +16,12 @@ public final class SlickSlickInputSystem extends AbstractSlickInputSystem {
   private final InputListener listener;
 
   /**
-   * Create the input system and set the listener that will receive any unused
-   * input events.
-   * 
-   * @param targetListener
-   *          the listener
-   * @throws IllegalArgumentException
-   *           in case the targetListener parameter is <code>null</code>
+   * Create the input system and set the listener that will receive any unused input events.
+   *
+   * @param targetListener the listener
+   * @throws IllegalArgumentException in case the targetListener parameter is {@code null}
    */
   public SlickSlickInputSystem(final InputListener targetListener) {
-    super();
     if (targetListener == null) {
       throw new IllegalArgumentException("The target listener must not be NULL.");
     }

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/input/events/AbstractKeyboardEvent.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/input/events/AbstractKeyboardEvent.java
@@ -4,34 +4,28 @@ import de.lessvoid.nifty.input.keyboard.KeyboardInputEvent;
 import de.lessvoid.nifty.slick2d.input.InputState;
 
 /**
- * This is the abstract keyboard event that stores the data all keyboard events
- * got in common.
- * 
+ * This is the abstract keyboard event that stores the data all keyboard events got in common.
+ *
  * @author Martin Karing &lt;nitram@illarion.org&gt;
  */
+@SuppressWarnings("AbstractClassExtendsConcreteClass")
 public abstract class AbstractKeyboardEvent extends KeyboardInputEvent implements InputEvent {
   /**
    * Create the keyboard event and store the ID of the key and the character.
-   * 
-   * @param keyId
-   *          the ID of the key that was used
-   * @param keyChar
-   *          the character assigned to the used key
-   * @param keyDown
-   *          <code>true</code> in case the key is pressed down
-   * @param shiftDown
-   *          <code>true</code> in case shift is pressed down at the same time
-   * @param controlDown
-   *          <code>true</code> in case control is pressed down at the same time
+   *
+   * @param keyId the ID of the key that was used
+   * @param keyChar the character assigned to the used key
+   * @param keyDown {@code true} in case the key is pressed down
+   * @param shiftDown {@code true} in case shift is pressed down at the same time
+   * @param controlDown {@code true} in case control is pressed down at the same time
    */
-  protected AbstractKeyboardEvent(final int keyId, final char keyChar, final boolean keyDown, final boolean shiftDown,
-      final boolean controlDown) {
+  protected AbstractKeyboardEvent(
+      final int keyId, final char keyChar, final boolean keyDown, final boolean shiftDown, final boolean controlDown) {
     super(keyId, keyChar, keyDown, shiftDown, controlDown);
   }
 
   /**
-   * {@inheritDoc} Default implementation allows this event to be executed in
-   * any case.
+   * {@inheritDoc} Default implementation allows this event to be executed in any case.
    */
   @Override
   public boolean executeEvent(final InputState state) {

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/input/events/AbstractKeyboardEvent.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/input/events/AbstractKeyboardEvent.java
@@ -1,6 +1,7 @@
 package de.lessvoid.nifty.slick2d.input.events;
 
 import de.lessvoid.nifty.input.keyboard.KeyboardInputEvent;
+import de.lessvoid.nifty.slick2d.input.ForwardingMode;
 import de.lessvoid.nifty.slick2d.input.InputState;
 
 /**
@@ -30,6 +31,11 @@ public abstract class AbstractKeyboardEvent extends KeyboardInputEvent implement
   @Override
   public boolean executeEvent(final InputState state) {
     return true;
+  }
+
+  @Override
+  public boolean isForwarded(final ForwardingMode mode) {
+    return (mode == ForwardingMode.keyboard) || (mode == ForwardingMode.all);
   }
 
   /**

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/input/events/AbstractMouseEvent.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/input/events/AbstractMouseEvent.java
@@ -1,5 +1,6 @@
 package de.lessvoid.nifty.slick2d.input.events;
 
+import de.lessvoid.nifty.slick2d.input.ForwardingMode;
 import de.lessvoid.nifty.slick2d.input.InputState;
 
 /**
@@ -53,6 +54,11 @@ public abstract class AbstractMouseEvent implements InputEvent {
    */
   protected final int getY() {
     return locY;
+  }
+
+  @Override
+  public boolean isForwarded(final ForwardingMode mode) {
+    return (mode == ForwardingMode.mouse) || (mode == ForwardingMode.all);
   }
 
   /**

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/input/events/AbstractMouseEvent.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/input/events/AbstractMouseEvent.java
@@ -3,9 +3,8 @@ package de.lessvoid.nifty.slick2d.input.events;
 import de.lessvoid.nifty.slick2d.input.InputState;
 
 /**
- * This is the abstract mouse event that stores only the data all mouse events
- * have in common.
- * 
+ * This is the abstract mouse event that stores only the data all mouse events have in common.
+ *
  * @author Martin Karing &lt;nitram@illarion.org&gt;
  */
 public abstract class AbstractMouseEvent implements InputEvent {
@@ -20,13 +19,10 @@ public abstract class AbstractMouseEvent implements InputEvent {
   private final int locY;
 
   /**
-   * Create a instance of this class and define the x and the y coordinate of
-   * the location where the event happened.
-   * 
-   * @param x
-   *          the x coordinate
-   * @param y
-   *          the y coordinate
+   * Create a instance of this class and define the x and the y coordinate of the location where the event happened.
+   *
+   * @param x the x coordinate
+   * @param y the y coordinate
    */
   protected AbstractMouseEvent(final int x, final int y) {
     locX = x;
@@ -34,8 +30,7 @@ public abstract class AbstractMouseEvent implements InputEvent {
   }
 
   /**
-   * {@inheritDoc} Default implementation allows this event to be executed in
-   * any case.
+   * {@inheritDoc} Default implementation allows this event to be executed in any case.
    */
   @Override
   public boolean executeEvent(final InputState state) {
@@ -44,7 +39,7 @@ public abstract class AbstractMouseEvent implements InputEvent {
 
   /**
    * Get the X coordinate of the location where the mouse event happened.
-   * 
+   *
    * @return the x coordinate of the event location
    */
   protected final int getX() {
@@ -53,7 +48,7 @@ public abstract class AbstractMouseEvent implements InputEvent {
 
   /**
    * Get the Y coordinate of the location where the mouse event happened.
-   * 
+   *
    * @return the y coordinate of the event location
    */
   protected final int getY() {

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/input/events/AbstractMouseEventButton.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/input/events/AbstractMouseEventButton.java
@@ -1,10 +1,9 @@
 package de.lessvoid.nifty.slick2d.input.events;
 
 /**
- * This is the basic mouse event for all mouse events that involve a mouse
- * button. In addition to the normal abstract mouse event this one is able to
- * store the button that was used.
- * 
+ * This is the basic mouse event for all mouse events that involve a mouse button. In addition to the normal abstract
+ * mouse event this one is able to store the button that was used.
+ *
  * @author Martin Karing &lt;nitram@illarion.org&gt;
  */
 public abstract class AbstractMouseEventButton extends AbstractMouseEvent {
@@ -15,13 +14,10 @@ public abstract class AbstractMouseEventButton extends AbstractMouseEvent {
 
   /**
    * Create the mouse event that involves a mouse button.
-   * 
-   * @param x
-   *          the x coordinate of the event location
-   * @param y
-   *          the y coordinate of the event location
-   * @param mouseButton
-   *          the mouse button that was used
+   *
+   * @param x the x coordinate of the event location
+   * @param y the y coordinate of the event location
+   * @param mouseButton the mouse button that was used
    */
   protected AbstractMouseEventButton(final int x, final int y, final int mouseButton) {
     super(x, y);
@@ -30,7 +26,7 @@ public abstract class AbstractMouseEventButton extends AbstractMouseEvent {
 
   /**
    * Get the ID of the button that was stored.
-   * 
+   *
    * @return the button ID
    */
   protected final int getButton() {

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/input/events/InputEvent.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/input/events/InputEvent.java
@@ -1,6 +1,7 @@
 package de.lessvoid.nifty.slick2d.input.events;
 
 import de.lessvoid.nifty.NiftyInputConsumer;
+import de.lessvoid.nifty.slick2d.input.ForwardingMode;
 import de.lessvoid.nifty.slick2d.input.InputState;
 import org.newdawn.slick.InputListener;
 
@@ -12,6 +13,14 @@ public interface InputEvent {
    * @return {@code true} in case this event is supposed to be executed
    */
   boolean executeEvent(InputState state);
+
+  /**
+   * Check if this input event is forwarded.
+   *
+   * @param mode the current forwarding mode
+   * @return {@code true} in case the event should be forwarded
+   */
+  boolean isForwarded(ForwardingMode mode);
 
   /**
    * Send the event to a nifty input consumer.

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/input/events/InputEvent.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/input/events/InputEvent.java
@@ -1,47 +1,41 @@
 package de.lessvoid.nifty.slick2d.input.events;
 
-import org.newdawn.slick.InputListener;
-
 import de.lessvoid.nifty.NiftyInputConsumer;
 import de.lessvoid.nifty.slick2d.input.InputState;
+import org.newdawn.slick.InputListener;
 
 public interface InputEvent {
   /**
    * Check if the input event is supposed to be executed.
-   * 
-   * @param state
-   *          the input event state
-   * @return <code>true</code> in case this event is supposed to be executed
+   *
+   * @param state the input event state
+   * @return {@code true} in case this event is supposed to be executed
    */
   boolean executeEvent(InputState state);
 
   /**
    * Send the event to a nifty input consumer.
-   * 
-   * @param consumer
-   *          the consumer the event needs to be send to
-   * @return <code>true</code> in case the event was handled by the consumer and
-   *         must not be forwarded to any other event handlers
+   *
+   * @param consumer the consumer the event needs to be send to
+   * @return {@code true} in case the event was handled by the consumer and must not be forwarded to any other event
+   *         handlers
    */
-  boolean sendToNifty(final NiftyInputConsumer consumer);
+  boolean sendToNifty(NiftyInputConsumer consumer);
 
   /**
    * Send the event to a slick input consumer.
-   * 
-   * @param listener
-   *          the input listener to receive this event
-   * @return <code>true</code> in case the event was handled by the consumer and
-   *         must not be forwarded to any other event handlers
+   *
+   * @param listener the input listener to receive this event
+   * @return {@code true} in case the event was handled by the consumer and must not be forwarded to any other event
+   *         handlers
    */
-  boolean sendToSlick(final InputListener listener);
+  boolean sendToSlick(InputListener listener);
 
   /**
    * Update the input event state.
-   * 
-   * @param state
-   *          the input event state to update
-   * @param handledByGUI
-   *          <code>true</code> if this event was handled by the GUI
+   *
+   * @param state the input event state to update
+   * @param handledByGUI {@code true} if this event was handled by the GUI
    */
   void updateState(InputState state, boolean handledByGUI);
 }

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/input/events/KeyboardEventPressed.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/input/events/KeyboardEventPressed.java
@@ -1,28 +1,24 @@
 package de.lessvoid.nifty.slick2d.input.events;
 
-import org.newdawn.slick.InputListener;
-
 import de.lessvoid.nifty.NiftyInputConsumer;
+import org.newdawn.slick.InputListener;
 
 /**
  * This class stores the data generated when pressing down a key.
- * 
+ *
  * @author Martin Karing &lt;nitram@illarion.org&gt;
  */
 public final class KeyboardEventPressed extends AbstractKeyboardEvent {
   /**
    * Create this new event key pressed event.
-   * 
-   * @param keyId
-   *          the ID of the key that was used
-   * @param keyChar
-   *          the character assigned to the used key
-   * @param shiftDown
-   *          <code>true</code> in case shift is pressed down at the same time
-   * @param controlDown
-   *          <code>true</code> in case control is pressed down at the same time
+   *
+   * @param keyId the ID of the key that was used
+   * @param keyChar the character assigned to the used key
+   * @param shiftDown {@code true} in case shift is pressed down at the same time
+   * @param controlDown {@code true} in case control is pressed down at the same time
    */
-  public KeyboardEventPressed(final int keyId, final char keyChar, final boolean shiftDown, final boolean controlDown) {
+  public KeyboardEventPressed(
+      final int keyId, final char keyChar, final boolean shiftDown, final boolean controlDown) {
     super(keyId, keyChar, true, shiftDown, controlDown);
   }
 

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/input/events/KeyboardEventReleased.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/input/events/KeyboardEventReleased.java
@@ -1,28 +1,24 @@
 package de.lessvoid.nifty.slick2d.input.events;
 
-import org.newdawn.slick.InputListener;
-
 import de.lessvoid.nifty.NiftyInputConsumer;
+import org.newdawn.slick.InputListener;
 
 /**
  * This class stores the data generated when releasing a key.
- * 
+ *
  * @author Martin Karing &lt;nitram@illarion.org&gt;
  */
 public final class KeyboardEventReleased extends AbstractKeyboardEvent {
   /**
    * Create this new event key released event.
-   * 
-   * @param keyId
-   *          the ID of the key that was used
-   * @param keyChar
-   *          the character assigned to the used key
-   * @param shiftDown
-   *          <code>true</code> in case shift is pressed down at the same time
-   * @param controlDown
-   *          <code>true</code> in case control is pressed down at the same time
+   *
+   * @param keyId the ID of the key that was used
+   * @param keyChar the character assigned to the used key
+   * @param shiftDown {@code true} in case shift is pressed down at the same time
+   * @param controlDown {@code true} in case control is pressed down at the same time
    */
-  public KeyboardEventReleased(final int keyId, final char keyChar, final boolean shiftDown, final boolean controlDown) {
+  public KeyboardEventReleased(
+      final int keyId, final char keyChar, final boolean shiftDown, final boolean controlDown) {
     super(keyId, keyChar, false, shiftDown, controlDown);
   }
 

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/input/events/MouseEventClicked.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/input/events/MouseEventClicked.java
@@ -1,14 +1,12 @@
 package de.lessvoid.nifty.slick2d.input.events;
 
-import org.newdawn.slick.InputListener;
-
 import de.lessvoid.nifty.NiftyInputConsumer;
 import de.lessvoid.nifty.slick2d.input.InputState;
+import org.newdawn.slick.InputListener;
 
 /**
- * This mouse event is used to store the event generated in case a mouse button
- * is clicked.
- * 
+ * This mouse event is used to store the event generated in case a mouse button is clicked.
+ *
  * @author Martin Karing &lt;nitram@illarion.org&gt;
  */
 public final class MouseEventClicked extends AbstractMouseEventButton {
@@ -19,15 +17,11 @@ public final class MouseEventClicked extends AbstractMouseEventButton {
 
   /**
    * Create a new mouse button clicked event.
-   * 
-   * @param x
-   *          the x coordinate of the event location
-   * @param y
-   *          the y coordinate of the event location
-   * @param mouseButton
-   *          the mouse button that was used
-   * @param clickCount
-   *          the count of times how often the button got clicked
+   *
+   * @param x the x coordinate of the event location
+   * @param y the y coordinate of the event location
+   * @param mouseButton the mouse button that was used
+   * @param clickCount the count of times how often the button got clicked
    */
   public MouseEventClicked(final int x, final int y, final int mouseButton, final int clickCount) {
     super(x, y, mouseButton);
@@ -45,8 +39,8 @@ public final class MouseEventClicked extends AbstractMouseEventButton {
   }
 
   /**
-   * This would send the event to Nifty, how ever Nifty does not use such
-   * high-level events and so its never send to Nifty.
+   * This would send the event to Nifty, how ever Nifty does not use such high-level events and so its never send to
+   * Nifty.
    */
   @Override
   public boolean sendToNifty(final NiftyInputConsumer consumer) {

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/input/events/MouseEventDragged.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/input/events/MouseEventDragged.java
@@ -1,13 +1,11 @@
 package de.lessvoid.nifty.slick2d.input.events;
 
+import de.lessvoid.nifty.NiftyInputConsumer;
 import org.newdawn.slick.InputListener;
 
-import de.lessvoid.nifty.NiftyInputConsumer;
-
 /**
- * This mouse event is used to store the event generated in case the mouse
- * cursor is moved with one button pressed.
- * 
+ * This mouse event is used to store the event generated in case the mouse cursor is moved with one button pressed.
+ *
  * @author Martin Karing &lt;nitram@illarion.org&gt;
  */
 public final class MouseEventDragged extends AbstractMouseEventButton {
@@ -23,17 +21,12 @@ public final class MouseEventDragged extends AbstractMouseEventButton {
 
   /**
    * Create a mouse dragged event.
-   * 
-   * @param mouseButton
-   *          the mouse button that was used
-   * @param startX
-   *          the X coordinate of the location where the movement started
-   * @param startY
-   *          the Y coordinate of the location where the movement started
-   * @param endX
-   *          the X coordinate of the location where the movement stopped
-   * @param endY
-   *          the Y coordinate of the location where the movement stopped
+   *
+   * @param mouseButton the mouse button that was used
+   * @param startX the X coordinate of the location where the movement started
+   * @param startY the Y coordinate of the location where the movement started
+   * @param endX the X coordinate of the location where the movement stopped
+   * @param endY the Y coordinate of the location where the movement stopped
    */
   public MouseEventDragged(final int mouseButton, final int startX, final int startY, final int endX, final int endY) {
     super(startX, startY, mouseButton);

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/input/events/MouseEventMoved.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/input/events/MouseEventMoved.java
@@ -1,13 +1,11 @@
 package de.lessvoid.nifty.slick2d.input.events;
 
+import de.lessvoid.nifty.NiftyInputConsumer;
 import org.newdawn.slick.InputListener;
 
-import de.lessvoid.nifty.NiftyInputConsumer;
-
 /**
- * This mouse event is used to store the event generated in case the mouse
- * cursor is moved.
- * 
+ * This mouse event is used to store the event generated in case the mouse cursor is moved.
+ *
  * @author Martin Karing &lt;nitram@illarion.org&gt;
  */
 public final class MouseEventMoved extends AbstractMouseEvent {
@@ -23,15 +21,11 @@ public final class MouseEventMoved extends AbstractMouseEvent {
 
   /**
    * Create a mouse moved event.
-   * 
-   * @param startX
-   *          the X coordinate of the location where the movement started
-   * @param startY
-   *          the Y coordinate of the location where the movement started
-   * @param endX
-   *          the X coordinate of the location where the movement stopped
-   * @param endY
-   *          the Y coordinate of the location where the movement stopped
+   *
+   * @param startX the X coordinate of the location where the movement started
+   * @param startY the Y coordinate of the location where the movement started
+   * @param endX the X coordinate of the location where the movement stopped
+   * @param endY the Y coordinate of the location where the movement stopped
    */
   public MouseEventMoved(final int startX, final int startY, final int endX, final int endY) {
     super(startX, startY);

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/input/events/MouseEventPressed.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/input/events/MouseEventPressed.java
@@ -1,26 +1,21 @@
 package de.lessvoid.nifty.slick2d.input.events;
 
-import org.newdawn.slick.InputListener;
-
 import de.lessvoid.nifty.NiftyInputConsumer;
 import de.lessvoid.nifty.slick2d.input.InputState;
+import org.newdawn.slick.InputListener;
 
 /**
- * This mouse event is used to store the event generated in case a mouse button
- * is pressed down.
- * 
+ * This mouse event is used to store the event generated in case a mouse button is pressed down.
+ *
  * @author Martin Karing &lt;nitram@illarion.org&gt;
  */
 public final class MouseEventPressed extends AbstractMouseEventButton {
   /**
    * Create a new mouse button pressed event.
-   * 
-   * @param x
-   *          the x coordinate of the event location
-   * @param y
-   *          the y coordinate of the event location
-   * @param mouseButton
-   *          the mouse button that was used
+   *
+   * @param x the x coordinate of the event location
+   * @param y the y coordinate of the event location
+   * @param mouseButton the mouse button that was used
    */
   public MouseEventPressed(final int x, final int y, final int mouseButton) {
     super(x, y, mouseButton);
@@ -44,8 +39,7 @@ public final class MouseEventPressed extends AbstractMouseEventButton {
   }
 
   /**
-   * Tell the state to consume the next click event in case the click happened
-   * upon the GUI.
+   * Tell the state to consume the next click event in case the click happened upon the GUI.
    */
   @Override
   public void updateState(final InputState state, final boolean handledByGUI) {

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/input/events/MouseEventPressed.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/input/events/MouseEventPressed.java
@@ -44,7 +44,7 @@ public final class MouseEventPressed extends AbstractMouseEventButton {
   }
 
   /**
-   * Tell the state to consume the next click event in case the click happend
+   * Tell the state to consume the next click event in case the click happened
    * upon the GUI.
    */
   @Override

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/input/events/MouseEventReleased.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/input/events/MouseEventReleased.java
@@ -1,25 +1,20 @@
 package de.lessvoid.nifty.slick2d.input.events;
 
+import de.lessvoid.nifty.NiftyInputConsumer;
 import org.newdawn.slick.InputListener;
 
-import de.lessvoid.nifty.NiftyInputConsumer;
-
 /**
- * This mouse event is used to store the event generated in case a mouse button
- * is released.
- * 
+ * This mouse event is used to store the event generated in case a mouse button is released.
+ *
  * @author Martin Karing &lt;nitram@illarion.org&gt;
  */
 public final class MouseEventReleased extends AbstractMouseEventButton {
   /**
    * Create a new mouse button release event.
-   * 
-   * @param x
-   *          the x coordinate of the event location
-   * @param y
-   *          the y coordinate of the event location
-   * @param mouseButton
-   *          the mouse button that was used
+   *
+   * @param x the x coordinate of the event location
+   * @param y the y coordinate of the event location
+   * @param mouseButton the mouse button that was used
    */
   public MouseEventReleased(final int x, final int y, final int mouseButton) {
     super(x, y, mouseButton);

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/input/events/MouseEventWheelMoved.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/input/events/MouseEventWheelMoved.java
@@ -1,31 +1,25 @@
 package de.lessvoid.nifty.slick2d.input.events;
 
+import de.lessvoid.nifty.NiftyInputConsumer;
 import org.newdawn.slick.InputListener;
 
-import de.lessvoid.nifty.NiftyInputConsumer;
-
 /**
- * This mouse event is used to store the event generated in case the mouse wheel
- * got moved.
- * 
+ * This mouse event is used to store the event generated in case the mouse wheel got moved.
+ *
  * @author Martin Karing &lt;nitram@illarion.org&gt;
  */
 public final class MouseEventWheelMoved extends AbstractMouseEvent {
   /**
-   * The delta value that defines how much and into what direction the mouse
-   * wheel got moved.
+   * The delta value that defines how much and into what direction the mouse wheel got moved.
    */
   private final int wheelDelta;
 
   /**
    * Create a new mouse wheel event and store the delta value.
-   * 
-   * @param x
-   *          the x coordinate
-   * @param y
-   *          the y coordinate
-   * @param delta
-   *          the delta of the mouse wheel movement
+   *
+   * @param x the x coordinate
+   * @param y the y coordinate
+   * @param delta the delta of the mouse wheel movement
    */
   public MouseEventWheelMoved(final int x, final int y, final int delta) {
     super(x, y);

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/loaders/AbstractSlickLoaders.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/loaders/AbstractSlickLoaders.java
@@ -43,7 +43,7 @@ public abstract class AbstractSlickLoaders<T extends SlickLoader> {
       loaders.add(0, newLoader);
       break;
     case last:
-    case dontCare:
+    case doNotCare:
     default:
       loaders.add(newLoader);
       break;

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/loaders/AbstractSlickLoaders.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/loaders/AbstractSlickLoaders.java
@@ -6,12 +6,11 @@ import java.util.List;
 
 /**
  * The abstract implementation of a resource loader.
- * 
+ *
+ * @param <T> The type of loader used by this loader list
  * @author Martin Karing &lt;nitram@illarion.org&gt;
- * @param <T>
- *          The type of loader used by this loader list
  */
-public abstract class AbstractSlickLoaders<T extends SlickLoader> {
+public abstract class AbstractSlickLoaders<T extends SlickLoader> implements SlickLoaders<T> {
   /**
    * The list of font loaders that are expected to be queried.
    */
@@ -21,49 +20,43 @@ public abstract class AbstractSlickLoaders<T extends SlickLoader> {
    * Create and prepare this class.
    */
   protected AbstractSlickLoaders() {
-    loaders = new ArrayList<T>();
+    loaders = new ArrayList<T>(1);
   }
 
   /**
-   * Add a loader to the list of loaders that get queried when loading a new
-   * resource.
-   * 
-   * @param newLoader
-   *          the new font loader
-   * @param order
-   *          the loader where the place the new loader on the list
+   * Add a loader to the list of loaders that get queried when loading a new resource.
+   *
+   * @param newLoader the new font loader
+   * @param order the loader where the place the new loader on the list
    */
-  public void addLoader(final T newLoader, final SlickAddLoaderLocation order) {
+  @Override
+  public final void addLoader(final T newLoader, final SlickAddLoaderLocation order) {
     if (checkAlreadyLoaded(newLoader)) {
       return;
     }
 
     switch (order) {
-    case first:
-      loaders.add(0, newLoader);
-      break;
-    case last:
-    case doNotCare:
-    default:
-      loaders.add(newLoader);
-      break;
+      case first:
+        loaders.add(0, newLoader);
+        break;
+      case last:
+      case doNotCare:
+        loaders.add(newLoader);
+        break;
     }
   }
 
   /**
-   * Check if the resource loader that is about to be added already a part of
-   * the loaders list. This is done be comparing the classes of the loaders.
-   * 
-   * @param newLoader
-   *          the loader that is to be added
-   * @return <code>true</code> in case the loader is already added to the
-   *         loaders list
+   * Check if the resource loader that is about to be added already a part of the loaders list. This is done be
+   * comparing the classes of the loaders.
+   *
+   * @param newLoader the loader that is to be added
+   * @return {@code true} in case the loader is already added to the loaders list
    */
   private boolean checkAlreadyLoaded(final T newLoader) {
     final Class<?> newLoaderClass = newLoader.getClass();
-    Class<?> currentLoaderClass;
     for (final T currentLoader : loaders) {
-      currentLoaderClass = currentLoader.getClass();
+      final Class<?> currentLoaderClass = currentLoader.getClass();
       if (newLoaderClass.equals(currentLoaderClass)) {
         return true;
       }
@@ -73,7 +66,7 @@ public abstract class AbstractSlickLoaders<T extends SlickLoader> {
 
   /**
    * Get the iterator that can be used to access all the loaders.
-   * 
+   *
    * @return the loader iterator
    */
   protected final Iterator<T> getLoaderIterator() {
@@ -83,15 +76,4 @@ public abstract class AbstractSlickLoaders<T extends SlickLoader> {
 
     return loaders.iterator();
   }
-
-  /**
-   * Add the default implemented loaders to the loader list. This is done
-   * automatically in case resources are requested but no loaders got
-   * registered. In general using this function should be avoided. Its better to
-   * load only the loaders that are actually needed for your resources.
-   * 
-   * @param order
-   *          the place where the default loaders are added to the list
-   */
-  public abstract void loadDefaultLoaders(final SlickAddLoaderLocation order);
 }

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/loaders/SlickAddLoaderLocation.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/loaders/SlickAddLoaderLocation.java
@@ -1,9 +1,9 @@
 package de.lessvoid.nifty.slick2d.loaders;
 
 /**
- * This enumerator is used to control the order of the loaders that is applied
- * when adding a new loader to the loaders list.
- * 
+ * This enumerator is used to control the order of the loaders that is applied when adding a new loader to the loaders
+ * list.
+ *
  * @author Martin Karing &lt;nitram@illarion.org&gt;
  */
 public enum SlickAddLoaderLocation {

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/loaders/SlickAddLoaderLocation.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/loaders/SlickAddLoaderLocation.java
@@ -10,7 +10,7 @@ public enum SlickAddLoaderLocation {
   /**
    * Add the loader where ever you like.
    */
-  dontCare,
+  doNotCare,
 
   /**
    * Add the loader to the top of the list, so its queried first.
@@ -20,5 +20,5 @@ public enum SlickAddLoaderLocation {
   /**
    * Add the loader to the bottom of the list, so its queried last.
    */
-  last;
+  last
 }

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/loaders/SlickLoadException.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/loaders/SlickLoadException.java
@@ -1,9 +1,9 @@
 package de.lessvoid.nifty.slick2d.loaders;
 
 /**
- * This exception is expected to be thrown be the constructor of this class in
- * case loading the specified resource failed.
- * 
+ * This exception is expected to be thrown be the constructor of this class in case loading the specified resource
+ * failed.
+ *
  * @author Martin Karing &lt;nitram@illarion.org&gt;
  */
 public class SlickLoadException extends Exception {
@@ -16,7 +16,6 @@ public class SlickLoadException extends Exception {
    * Create the exception without an attached message or parent Throwable.
    */
   public SlickLoadException() {
-    super();
   }
 
   /**

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/loaders/SlickLoadException.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/loaders/SlickLoadException.java
@@ -17,26 +17,33 @@ public class SlickLoadException extends Exception {
    */
   public SlickLoadException() {
     super();
-  };
+  }
 
   /**
    * Create the exception with an attached message and without parent Throwable.
+   *
+   * @param msg The message that is attached to this exception
    */
   public SlickLoadException(final String msg) {
     super(msg);
-  };
+  }
 
   /**
    * Create the exception with an attached message and parent Throwable.
+   *
+   * @param msg The message that is attached to this exception
+   * @param e The throwable that caused this exception
    */
   public SlickLoadException(final String msg, final Throwable e) {
     super(msg, e);
-  };
+  }
 
   /**
    * Create the exception without an attached message and with parent Throwable.
+   *
+   * @param e The throwable that caused this exception
    */
   public SlickLoadException(final Throwable e) {
     super(e);
-  };
+  }
 }

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/loaders/SlickLoader.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/loaders/SlickLoader.java
@@ -1,9 +1,8 @@
 package de.lessvoid.nifty.slick2d.loaders;
 
 /**
- * This interface is the general interface for any resource loader that is
- * defined for this Nifty-Slick renderer.
- * 
+ * This interface is the general interface for any resource loader that is defined for this Nifty-Slick renderer.
+ *
  * @author Martin Karing &lt;nitram@illarion.org&gt;
  */
 public interface SlickLoader {

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/loaders/SlickLoaders.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/loaders/SlickLoaders.java
@@ -1,0 +1,26 @@
+package de.lessvoid.nifty.slick2d.loaders;
+
+/**
+ * This is the interface of any loader collection that is used inside the Slick2D render binding.
+ *
+ * @param <T> The type of loader used by this loader list
+ * @author Martin Karing &lt;nitram@illarion.org&gt;
+ */
+public interface SlickLoaders<T extends SlickLoader> {
+  /**
+   * Add a loader to the list of loaders that get queried when loading a new resource.
+   *
+   * @param newLoader the new font loader
+   * @param order the loader where the place the new loader on the list
+   */
+  void addLoader(T newLoader, SlickAddLoaderLocation order);
+
+  /**
+   * Add the default implemented loaders to the loader list. This is done automatically in case resources are requested
+   * but no loaders got registered. In general using this function should be avoided. Its better to load only the
+   * loaders that are actually needed for your resources.
+   *
+   * @param order the place where the default loaders are added to the list
+   */
+  void loadDefaultLoaders(SlickAddLoaderLocation order);
+}

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/loaders/SlickMouseCursorLoaders.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/loaders/SlickMouseCursorLoaders.java
@@ -8,9 +8,8 @@ import de.lessvoid.nifty.slick2d.render.cursor.loader.LwjglCursorSlickMouseCurso
 import de.lessvoid.nifty.slick2d.render.cursor.loader.SlickMouseCursorLoader;
 
 /**
- * This maintains the list of known cursor loaders and queries them one by one
- * in order to load a cursor.
- * 
+ * This maintains the list of known cursor loaders and queries them one by one in order to load a cursor.
+ *
  * @author Martin Karing &lt;nitram@illarion.org&gt;
  */
 public final class SlickMouseCursorLoaders extends AbstractSlickLoaders<SlickMouseCursorLoader> {
@@ -21,7 +20,7 @@ public final class SlickMouseCursorLoaders extends AbstractSlickLoaders<SlickMou
 
   /**
    * Get the singleton instance of this class.
-   * 
+   *
    * @return the singleton instance
    */
   public static SlickMouseCursorLoaders getInstance() {
@@ -32,29 +31,25 @@ public final class SlickMouseCursorLoaders extends AbstractSlickLoaders<SlickMou
    * Private constructor so no instances but the singleton instance are created.
    */
   private SlickMouseCursorLoaders() {
-    super();
   }
 
   /**
    * Load a mouse cursor.
-   * 
-   * @param filename
-   *          the name of the file that stores the image of this cursor
-   * @param hotspotX
-   *          the x coordinate of the cursor hotspot
-   * @param hotspotY
-   *          the y coordinate of the cursor hotspot
+   *
+   * @param filename the name of the file that stores the image of this cursor
+   * @param hotspotX the x coordinate of the cursor hotspot
+   * @param hotspotY the y coordinate of the cursor hotspot
    * @return the loaded mouse cursor
-   * @throws IllegalArgumentException
-   *           in case all loaders fail to load this cursor
+   * @throws IllegalArgumentException in case all loaders fail to load this cursor
    */
+  @SuppressWarnings("TypeMayBeWeakened")
   public SlickMouseCursor loadCursor(final String filename, final int hotspotX, final int hotspotY) {
     final Iterator<SlickMouseCursorLoader> itr = getLoaderIterator();
 
     while (itr.hasNext()) {
       try {
         return itr.next().loadCursor(filename, hotspotX, hotspotY);
-      } catch (final SlickLoadCursorException e) {
+      } catch (final SlickLoadCursorException ignored) {
         // this loader failed... does not matter
       }
     }

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/loaders/SlickMusicLoaders.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/loaders/SlickMusicLoaders.java
@@ -9,9 +9,8 @@ import de.lessvoid.nifty.slick2d.sound.music.loader.SlickMusicLoader;
 import de.lessvoid.nifty.sound.SoundSystem;
 
 /**
- * This maintains the list of known music loaders and queries them one by one in
- * order to load a music.
- * 
+ * This maintains the list of known music loaders and queries them one by one in order to load a music.
+ *
  * @author Martin Karing &lt;nitram@illarion.org&gt;
  */
 public final class SlickMusicLoaders extends AbstractSlickLoaders<SlickMusicLoader> {
@@ -22,7 +21,7 @@ public final class SlickMusicLoaders extends AbstractSlickLoaders<SlickMusicLoad
 
   /**
    * Get the singleton instance of this class.
-   * 
+   *
    * @return the singleton instance
    */
   public static SlickMusicLoaders getInstance() {
@@ -33,7 +32,6 @@ public final class SlickMusicLoaders extends AbstractSlickLoaders<SlickMusicLoad
    * Private constructor so no instances but the singleton instance are created.
    */
   private SlickMusicLoaders() {
-    super();
   }
 
   /**
@@ -46,22 +44,20 @@ public final class SlickMusicLoaders extends AbstractSlickLoaders<SlickMusicLoad
 
   /**
    * Load a music using the registered loaders.
-   * 
-   * @param soundSystem
-   *          the sound system that stores the sound data
-   * @param filename
-   *          the name of the file that holds the music
+   *
+   * @param soundSystem the sound system that stores the sound data
+   * @param filename the name of the file that holds the music
    * @return the loaded music
-   * @throws IllegalArgumentException
-   *           in case loading the music fails
+   * @throws IllegalArgumentException in case loading the music fails
    */
+  @SuppressWarnings("TypeMayBeWeakened")
   public SlickMusicHandle loadMusic(final SoundSystem soundSystem, final String filename) {
     final Iterator<SlickMusicLoader> itr = getLoaderIterator();
 
     while (itr.hasNext()) {
       try {
         return itr.next().loadMusic(soundSystem, filename);
-      } catch (final SlickLoadMusicException e) {
+      } catch (final SlickLoadMusicException ignored) {
         // this loader failed... does not matter
       }
     }

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/loaders/SlickRenderFontLoaders.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/loaders/SlickRenderFontLoaders.java
@@ -59,7 +59,7 @@ public final class SlickRenderFontLoaders extends AbstractSlickLoaders<SlickRend
       addLoader(new UnicodeSlickRenderFontLoader(), order);
       break;
     case last:
-    case dontCare:
+    case doNotCare:
     default:
       addLoader(new UnicodeSlickRenderFontLoader(), order);
       addLoader(new HieroUnicodeSlickRenderFontLoader(), order);

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/loaders/SlickRenderFontLoaders.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/loaders/SlickRenderFontLoaders.java
@@ -2,20 +2,16 @@ package de.lessvoid.nifty.slick2d.loaders;
 
 import java.util.Iterator;
 
-import org.newdawn.slick.Graphics;
-
 import de.lessvoid.nifty.slick2d.render.font.SlickLoadFontException;
 import de.lessvoid.nifty.slick2d.render.font.SlickRenderFont;
-import de.lessvoid.nifty.slick2d.render.font.loader.AngelCodeSlickRenderFontLoader;
-import de.lessvoid.nifty.slick2d.render.font.loader.DefaultSlickRenderFontLoader;
-import de.lessvoid.nifty.slick2d.render.font.loader.HieroUnicodeSlickRenderFontLoader;
-import de.lessvoid.nifty.slick2d.render.font.loader.SlickRenderFontLoader;
-import de.lessvoid.nifty.slick2d.render.font.loader.UnicodeSlickRenderFontLoader;
+import de.lessvoid.nifty.slick2d.render.font.loader.*;
+import org.newdawn.slick.Graphics;
 
 /**
- * This class is used to trigger the actual font loading. It will query all the
- * font loaders and try to load a font with the specified name.
- * 
+ * This class is used to trigger the actual font loading. It will query all the font loaders and try to load a font
+ * with
+ * the specified name.
+ *
  * @author Martin Karing &lt;nitram@illarion.org&gt;
  */
 public final class SlickRenderFontLoaders extends AbstractSlickLoaders<SlickRenderFontLoader> {
@@ -26,7 +22,7 @@ public final class SlickRenderFontLoaders extends AbstractSlickLoaders<SlickRend
 
   /**
    * Get the singleton instance of this class.
-   * 
+   *
    * @return the singleton instance
    */
   public static SlickRenderFontLoaders getInstance() {
@@ -37,71 +33,61 @@ public final class SlickRenderFontLoaders extends AbstractSlickLoaders<SlickRend
    * Private constructor so no instances but the singleton instance are created.
    */
   private SlickRenderFontLoaders() {
-    super();
   }
 
   /**
-   * Add the default implemented loaders to the loader list. This is done
-   * automatically in case fonts are requested but no loaders got registered. In
-   * general using this function should be avoided. Its better to load only the
-   * loaders that are actually needed for your resources.
-   * 
-   * @param order
-   *          the place where the default loaders are added to the list
+   * Add the default implemented loaders to the loader list. This is done automatically in case fonts are requested but
+   * no loaders got registered. In general using this function should be avoided. Its better to load only the loaders
+   * that are actually needed for your resources.
+   *
+   * @param order the place where the default loaders are added to the list
    */
   @Override
   public void loadDefaultLoaders(final SlickAddLoaderLocation order) {
     switch (order) {
-    case first:
-      addLoader(new DefaultSlickRenderFontLoader(), order);
-      addLoader(new AngelCodeSlickRenderFontLoader(), order);
-      addLoader(new HieroUnicodeSlickRenderFontLoader(), order);
-      addLoader(new UnicodeSlickRenderFontLoader(), order);
-      break;
-    case last:
-    case doNotCare:
-    default:
-      addLoader(new UnicodeSlickRenderFontLoader(), order);
-      addLoader(new HieroUnicodeSlickRenderFontLoader(), order);
-      addLoader(new AngelCodeSlickRenderFontLoader(), order);
-      addLoader(new DefaultSlickRenderFontLoader(), order);
-      break;
+      case first:
+        addLoader(new DefaultSlickRenderFontLoader(), order);
+        addLoader(new AngelCodeSlickRenderFontLoader(), order);
+        addLoader(new HieroUnicodeSlickRenderFontLoader(), order);
+        addLoader(new UnicodeSlickRenderFontLoader(), order);
+        break;
+      case last:
+      case doNotCare:
+        addLoader(new UnicodeSlickRenderFontLoader(), order);
+        addLoader(new HieroUnicodeSlickRenderFontLoader(), order);
+        addLoader(new AngelCodeSlickRenderFontLoader(), order);
+        addLoader(new DefaultSlickRenderFontLoader(), order);
+        break;
     }
   }
 
   /**
-   * Add the loaders to the loader list that are flagged as deprecated. In
-   * general its a bad idea to do this.
-   * 
-   * @param order
-   *          the place where the deprecated loaders are added to the list
+   * Add the loaders to the loader list that are flagged as deprecated. In general its a bad idea to do this.
+   *
+   * @param order the place where the deprecated loaders are added to the list
    * @deprecated loads deprecated font loaders
    */
   @Deprecated
   public void loadDeprecatedLoaders(final SlickAddLoaderLocation order) {
-    addLoader(
-        new de.lessvoid.nifty.slick2d.render.font.loader.TrueTypeSlickRenderFontLoader(), 
-        order);
+    addLoader(new TrueTypeSlickRenderFontLoader(), order);
   }
 
   /**
    * Load the font with the defined name.
-   * 
-   * @param g
-   *          the graphics instance used for rendering
-   * @param filename
-   *          name of the file that contains the font
+   *
+   * @param g the graphics instance used for rendering
+   * @param filename name of the file that contains the font
    * @return the font loaded
-   * @throws IllegalArgumentException
-   *           in case all loaders fail to load the font
+   * @throws IllegalArgumentException in case all loaders fail to load the font
    */
+  @SuppressWarnings("TypeMayBeWeakened")
   public SlickRenderFont loadFont(final Graphics g, final String filename) {
     final Iterator<SlickRenderFontLoader> itr = getLoaderIterator();
 
     while (itr.hasNext()) {
       try {
         return itr.next().loadFont(g, filename);
-      } catch (final SlickLoadFontException e) {
+      } catch (final SlickLoadFontException ignored) {
         // this loader failed... does not matter
       }
     }

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/loaders/SlickRenderImageLoaders.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/loaders/SlickRenderImageLoaders.java
@@ -8,9 +8,9 @@ import de.lessvoid.nifty.slick2d.render.image.loader.ImageSlickRenderImageLoader
 import de.lessvoid.nifty.slick2d.render.image.loader.SlickRenderImageLoader;
 
 /**
- * This class is used to trigger the actual image loading. It will query all
- * known image loaders in order to load the render image.
- * 
+ * This class is used to trigger the actual image loading. It will query all known image loaders in order to load the
+ * render image.
+ *
  * @author Martin Karing &lt;nitram@illarion.org&gt;
  */
 public final class SlickRenderImageLoaders extends AbstractSlickLoaders<SlickRenderImageLoader> {
@@ -21,7 +21,7 @@ public final class SlickRenderImageLoaders extends AbstractSlickLoaders<SlickRen
 
   /**
    * Get the singleton instance of this class.
-   * 
+   *
    * @return the singleton instance
    */
   public static SlickRenderImageLoaders getInstance() {
@@ -32,7 +32,6 @@ public final class SlickRenderImageLoaders extends AbstractSlickLoaders<SlickRen
    * Private constructor so no instances but the singleton instance are created.
    */
   private SlickRenderImageLoaders() {
-    super();
   }
 
   /**
@@ -45,23 +44,20 @@ public final class SlickRenderImageLoaders extends AbstractSlickLoaders<SlickRen
 
   /**
    * Load the image with the defined name.
-   * 
-   * @param filename
-   *          name of the file that contains the image
-   * @param filterLinear
-   *          <code>true</code> in case a linear filter should be applied when
-   *          resizing this image
+   *
+   * @param filename name of the file that contains the image
+   * @param filterLinear {@code true} in case a linear filter should be applied when resizing this image
    * @return the image loaded
-   * @throws IllegalArgumentException
-   *           in case all loaders fail to load the image
+   * @throws IllegalArgumentException in case all loaders fail to load the image
    */
+  @SuppressWarnings("TypeMayBeWeakened")
   public SlickRenderImage loadImage(final String filename, final boolean filterLinear) {
     final Iterator<SlickRenderImageLoader> itr = getLoaderIterator();
 
     while (itr.hasNext()) {
       try {
         return itr.next().loadImage(filename, filterLinear);
-      } catch (final SlickLoadImageException e) {
+      } catch (final SlickLoadImageException ignored) {
         // this loader failed... does not matter
       }
     }

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/loaders/SlickSoundLoaders.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/loaders/SlickSoundLoaders.java
@@ -9,9 +9,8 @@ import de.lessvoid.nifty.slick2d.sound.sound.loader.SoundSlickSoundLoader;
 import de.lessvoid.nifty.sound.SoundSystem;
 
 /**
- * This maintains the list of known sound loaders and queries them one by one in
- * order to load a sound.
- * 
+ * This maintains the list of known sound loaders and queries them one by one in order to load a sound.
+ *
  * @author Martin Karing &lt;nitram@illarion.org&gt;
  */
 public final class SlickSoundLoaders extends AbstractSlickLoaders<SlickSoundLoader> {
@@ -22,7 +21,7 @@ public final class SlickSoundLoaders extends AbstractSlickLoaders<SlickSoundLoad
 
   /**
    * Get the singleton instance of this class.
-   * 
+   *
    * @return the singleton instance
    */
   public static SlickSoundLoaders getInstance() {
@@ -33,7 +32,6 @@ public final class SlickSoundLoaders extends AbstractSlickLoaders<SlickSoundLoad
    * Private constructor so no instances but the singleton instance are created.
    */
   private SlickSoundLoaders() {
-    super();
   }
 
   /**
@@ -46,22 +44,20 @@ public final class SlickSoundLoaders extends AbstractSlickLoaders<SlickSoundLoad
 
   /**
    * Load a sound using the registered loaders.
-   * 
-   * @param soundSystem
-   *          the sound system that stores the sound data
-   * @param filename
-   *          the name of the file that holds the sound
+   *
+   * @param soundSystem the sound system that stores the sound data
+   * @param filename the name of the file that holds the sound
    * @return the loaded sound
-   * @throws IllegalArgumentException
-   *           in case loading the sound fails
+   * @throws IllegalArgumentException in case loading the sound fails
    */
+  @SuppressWarnings("TypeMayBeWeakened")
   public SlickSoundHandle loadSound(final SoundSystem soundSystem, final String filename) {
     final Iterator<SlickSoundLoader> itr = getLoaderIterator();
 
     while (itr.hasNext()) {
       try {
         return itr.next().loadSound(soundSystem, filename);
-      } catch (final SlickLoadSoundException e) {
+      } catch (final SlickLoadSoundException ignored) {
         // this loader failed... does not matter
       }
     }

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/SlickQuadFill.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/SlickQuadFill.java
@@ -6,10 +6,9 @@ import org.newdawn.slick.geom.Shape;
 import org.newdawn.slick.geom.Vector2f;
 
 /**
- * This shape fill implementation is used to render the rectangles of slick that
- * that have a different color on each edge. This implementation is not supposed
- * to be used for any other purpose.
- * 
+ * This shape fill implementation is used to render the rectangles of slick that that have a different color on each
+ * edge. This implementation is not supposed to be used for any other purpose.
+ *
  * @author Martin Karing &lt;nitram@illarion.org&gt;
  */
 final class SlickQuadFill implements ShapeFill {
@@ -40,18 +39,17 @@ final class SlickQuadFill implements ShapeFill {
 
   /**
    * Create a new rectangle filling instance.
-   * 
-   * @param tlColor
-   *          the color at the top left
-   * @param trColor
-   *          the color at the top right
-   * @param blColor
-   *          the color at the bottom left
-   * @param brColor
-   *          the color at the bottom right
+   *
+   * @param tlColor the color at the top left
+   * @param trColor the color at the top right
+   * @param blColor the color at the bottom left
+   * @param brColor the color at the bottom right
    */
-  public SlickQuadFill(final de.lessvoid.nifty.tools.Color tlColor, final de.lessvoid.nifty.tools.Color trColor,
-      final de.lessvoid.nifty.tools.Color blColor, final de.lessvoid.nifty.tools.Color brColor) {
+  SlickQuadFill(
+      final de.lessvoid.nifty.tools.Color tlColor,
+      final de.lessvoid.nifty.tools.Color trColor,
+      final de.lessvoid.nifty.tools.Color blColor,
+      final de.lessvoid.nifty.tools.Color brColor) {
 
     topLeft = SlickRenderUtils.convertColorNiftySlick(tlColor);
     topRight = SlickRenderUtils.convertColorNiftySlick(trColor);
@@ -61,15 +59,11 @@ final class SlickQuadFill implements ShapeFill {
 
   /**
    * Change all the color values.
-   * 
-   * @param tlColor
-   *          the color at the top left
-   * @param trColor
-   *          the color at the top right
-   * @param blColor
-   *          the color at the bottom left
-   * @param brColor
-   *          the color at the bottom right
+   *
+   * @param tlColor the color at the top left
+   * @param trColor the color at the top right
+   * @param blColor the color at the bottom left
+   * @param brColor the color at the bottom right
    */
   public void changeColors(
       final de.lessvoid.nifty.tools.Color tlColor,
@@ -88,21 +82,14 @@ final class SlickQuadFill implements ShapeFill {
    */
   @Override
   public Color colorAt(final Shape shape, final float x, final float y) {
-    final boolean isMaxX = (Math.abs(x - shape.getMaxX()) < 0.001f);
-    final boolean isMaxY = (Math.abs(y - shape.getMaxY()) < 0.001f);
+    final boolean isMaxX = Math.abs(x - shape.getMaxX()) < 0.0f;
+    final boolean isMaxY = Math.abs(y - shape.getMaxY()) < 0.0f;
 
+    //noinspection IfMayBeConditional
     if (isMaxX) {
-      if (isMaxY) {
-        return topRight;
-      } else {
-        return topLeft;
-      }
+      return isMaxY ? topRight : topLeft;
     } else {
-      if (isMaxY) {
-        return bottomRight;
-      } else {
-        return bottomLeft;
-      }
+      return isMaxY ? bottomRight : bottomLeft;
     }
   }
 

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/SlickRenderDevice.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/SlickRenderDevice.java
@@ -1,12 +1,5 @@
 package de.lessvoid.nifty.slick2d.render;
 
-import java.io.IOException;
-
-import org.newdawn.slick.GameContainer;
-import org.newdawn.slick.Graphics;
-import org.newdawn.slick.Input;
-import org.newdawn.slick.geom.Rectangle;
-
 import de.lessvoid.nifty.render.BlendMode;
 import de.lessvoid.nifty.slick2d.loaders.SlickMouseCursorLoaders;
 import de.lessvoid.nifty.slick2d.loaders.SlickRenderFontLoaders;
@@ -20,46 +13,46 @@ import de.lessvoid.nifty.spi.render.RenderFont;
 import de.lessvoid.nifty.spi.render.RenderImage;
 import de.lessvoid.nifty.tools.Color;
 import de.lessvoid.nifty.tools.resourceloader.NiftyResourceLoader;
+import org.newdawn.slick.GameContainer;
+import org.newdawn.slick.Graphics;
+import org.newdawn.slick.Input;
+import org.newdawn.slick.geom.Rectangle;
 
 /**
- * The render device that takes care for rendering the Nifty GUI inside of
- * Slick.
- * 
+ * The render device that takes care for rendering the Nifty GUI inside of Slick.
+ *
  * @author Martin Karing &lt;nitram@illarion.org&gt;
  */
 public final class SlickRenderDevice implements RenderDevice {
   /**
    * The mouse cursor that is currently active.
    */
-  private SlickMouseCursor activeMouseCursor;
+  private SlickMouseCursor activeMouseCursor = null;
 
   /**
-   * The game container that hosts the render area the Nifty GUI is supposed to
-   * be rendered inside
+   * The game container that hosts the render area the Nifty GUI is supposed to be rendered inside
    */
   private final GameContainer gameContainer;
 
   /**
    * The shape filling instance that is used to render the 4 colored rectangles.
    */
-  private SlickQuadFill quadFill;
+  private SlickQuadFill quadFill = null;
 
   /**
-   * This temporary slick color is just used to avoid the need to create Slick
-   * Color instances again and again for a short time while rendering.
+   * This temporary slick color is just used to avoid the need to create Slick Color instances again and again for a
+   * short time while rendering.
    */
   private final org.newdawn.slick.Color tempSlickColor;
 
   /**
-   * Create a new render device and set the game container used to render the
-   * GUI inside.
-   * 
-   * @param gameContainer
-   *          the game container
+   * Create a new render device and set the game container used to render the GUI inside.
+   *
+   * @param container the game container
    */
-  public SlickRenderDevice(final GameContainer gameContainer) {
-    this.gameContainer = gameContainer;
-    tempSlickColor = new org.newdawn.slick.Color(0.f, 0.f, 0.f, 0.f);
+  public SlickRenderDevice(final GameContainer container) {
+    gameContainer = container;
+    tempSlickColor = new org.newdawn.slick.Color(0.0f, 0.0f, 0.0f, 0.0f);
   }
 
   /**
@@ -96,8 +89,7 @@ public final class SlickRenderDevice implements RenderDevice {
    * Create a new mouse cursor.
    */
   @Override
-  public MouseCursor createMouseCursor(final String filename, final int hotspotX, final int hotspotY)
-      throws IOException {
+  public MouseCursor createMouseCursor(final String filename, final int hotspotX, final int hotspotY) {
     return SlickMouseCursorLoaders.getInstance().loadCursor(filename, hotspotX, hotspotY);
   }
 
@@ -277,7 +269,7 @@ public final class SlickRenderDevice implements RenderDevice {
   @Override
   public void setBlendMode(final BlendMode renderMode) {
     final Graphics g = gameContainer.getGraphics();
-    
+
     if (renderMode == BlendMode.BLEND) {
       g.setDrawMode(Graphics.MODE_NORMAL);
     } else {

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/SlickRenderUtils.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/SlickRenderUtils.java
@@ -1,37 +1,34 @@
 package de.lessvoid.nifty.slick2d.render;
 
+import de.lessvoid.nifty.tools.Color;
+
 /**
  * This utility class implements some utility functions for the render classes.
- * 
+ *
  * @author Martin Karing &lt;nitram@illarion.org&gt;
  */
 public final class SlickRenderUtils {
   /**
    * Convert a Nifty color into a Slick color.
-   * 
-   * @param niftyColor
-   *          the Nifty color that supplies the color values
-   * @return the newly created instance of a Slick color that stores the same
-   *         color values as the Nifty color that was set as parameter
+   *
+   * @param niftyColor the Nifty color that supplies the color values
+   * @return the newly created instance of a Slick color that stores the same color values as the Nifty color that was
+   *         set as parameter
    */
-  public static org.newdawn.slick.Color convertColorNiftySlick(final de.lessvoid.nifty.tools.Color niftyColor) {
+  public static org.newdawn.slick.Color convertColorNiftySlick(final Color niftyColor) {
     return new org.newdawn.slick.Color(niftyColor.getRed(), niftyColor.getGreen(), niftyColor.getBlue(),
         niftyColor.getAlpha());
   }
 
   /**
    * Convert a Nifty color into a Slick color.
-   * 
-   * @param niftyColor
-   *          the Nifty color that supplies the color values
-   * @param slickColor
-   *          the instance of a Slick color that is supposed to store the color
-   *          values
+   *
+   * @param niftyColor the Nifty color that supplies the color values
+   * @param slickColor the instance of a Slick color that is supposed to store the color values
    * @return the same instance of the Slick color that was set as parameter
    */
   public static org.newdawn.slick.Color convertColorNiftySlick(
-      final de.lessvoid.nifty.tools.Color niftyColor,
-      final org.newdawn.slick.Color slickColor) {
+      final Color niftyColor, final org.newdawn.slick.Color slickColor) {
     slickColor.r = niftyColor.getRed();
     slickColor.g = niftyColor.getGreen();
     slickColor.b = niftyColor.getBlue();
@@ -41,29 +38,23 @@ public final class SlickRenderUtils {
 
   /**
    * Convert a Slick color into a Nifty color.
-   * 
-   * @param slickColor
-   *          the Slick color that supplies the color values
-   * @return the newly created Nifty color instance that stores the values of
-   *         the Slick color set as parameter
+   *
+   * @param slickColor the Slick color that supplies the color values
+   * @return the newly created Nifty color instance that stores the values of the Slick color set as parameter
    */
-  public static de.lessvoid.nifty.tools.Color convertColorSlickNifty(final org.newdawn.slick.Color slickColor) {
-    return new de.lessvoid.nifty.tools.Color(slickColor.r, slickColor.g, slickColor.b, slickColor.a);
+  public static Color convertColorSlickNifty(final org.newdawn.slick.Color slickColor) {
+    return new Color(slickColor.r, slickColor.g, slickColor.b, slickColor.a);
   }
 
   /**
    * Convert a Slick color to a Nifty color.
-   * 
-   * @param slickColor
-   *          the Slick color that supplies the color values
-   * @param niftyColor
-   *          the Nifty color that is supposed to store the values of the Slick
-   *          color
+   *
+   * @param slickColor the Slick color that supplies the color values
+   * @param niftyColor the Nifty color that is supposed to store the values of the Slick color
    * @return the same instances of the Nifty color that is set as parameter
    */
-  public static de.lessvoid.nifty.tools.Color convertColorSlickNifty(
-      final org.newdawn.slick.Color slickColor,
-      final de.lessvoid.nifty.tools.Color niftyColor) {
+  public static Color convertColorSlickNifty(
+      final org.newdawn.slick.Color slickColor, final Color niftyColor) {
     niftyColor.setRed(slickColor.r);
     niftyColor.setGreen(slickColor.g);
     niftyColor.setBlue(slickColor.b);

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/cursor/AbstractNativeSlickMouseCursor.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/cursor/AbstractNativeSlickMouseCursor.java
@@ -3,16 +3,14 @@ package de.lessvoid.nifty.slick2d.render.cursor;
 import org.newdawn.slick.Graphics;
 
 /**
- * This class is created to implement native mouse cursors with slick. Those
- * cursor are not in need of the render function and so this function is
- * implemented empty.
- * 
+ * This class is created to implement native mouse cursors with slick. Those cursor are not in need of the render
+ * function and so this function is implemented empty.
+ *
  * @author Martin Karing &lt;nitram@illarion.org&gt;
  */
 public abstract class AbstractNativeSlickMouseCursor implements SlickMouseCursor {
   /**
-   * Render the cursor. For the native implementations this function does
-   * nothing at all.
+   * Render the cursor. For the native implementations this function does nothing at all.
    */
   @Override
   public final void render(final Graphics g, final int x, final int y) {

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/cursor/LwjglCursorSlickMouseCursor.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/cursor/LwjglCursorSlickMouseCursor.java
@@ -1,13 +1,13 @@
 package de.lessvoid.nifty.slick2d.render.cursor;
 
 import org.lwjgl.input.Cursor;
+
 import org.newdawn.slick.GameContainer;
 import org.newdawn.slick.SlickException;
 
 /**
- * This implementation of the slick mouse cursor uses the LWJGL cursor
- * implementation to display the mouse cursor.
- * 
+ * This implementation of the slick mouse cursor uses the LWJGL cursor implementation to display the mouse cursor.
+ *
  * @author Martin Karing &lt;nitram@illarion.org&gt;
  */
 public class LwjglCursorSlickMouseCursor extends AbstractNativeSlickMouseCursor {
@@ -18,12 +18,10 @@ public class LwjglCursorSlickMouseCursor extends AbstractNativeSlickMouseCursor 
 
   /**
    * Create a new slick mouse cursor that wraps a LWJGL cursor.
-   * 
-   * @param lwjglCursor
-   *          the lwjgl cursor
+   *
+   * @param lwjglCursor the lwjgl cursor
    */
   public LwjglCursorSlickMouseCursor(final Cursor lwjglCursor) {
-    super();
     cursor = lwjglCursor;
   }
 
@@ -50,7 +48,7 @@ public class LwjglCursorSlickMouseCursor extends AbstractNativeSlickMouseCursor 
   public void enableCursor(final GameContainer container) {
     try {
       container.setMouseCursor(cursor, 0, 0);
-    } catch (final SlickException e) {
+    } catch (final SlickException ignored) {
       // enabling failed
     }
   }

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/cursor/SlickLoadCursorException.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/cursor/SlickLoadCursorException.java
@@ -3,9 +3,9 @@ package de.lessvoid.nifty.slick2d.render.cursor;
 import de.lessvoid.nifty.slick2d.loaders.SlickLoadException;
 
 /**
- * This exception is expected to be thrown be the constructor of this class in
- * case loading the specified mouse cursor failed.
- * 
+ * This exception is expected to be thrown be the constructor of this class in case loading the specified mouse cursor
+ * failed.
+ *
  * @author Martin Karing &lt;nitram@illarion.org&gt;
  */
 public final class SlickLoadCursorException extends SlickLoadException {
@@ -18,7 +18,6 @@ public final class SlickLoadCursorException extends SlickLoadException {
    * Create the exception without an attached message or parent Throwable.
    */
   public SlickLoadCursorException() {
-    super();
   }
 
   /**

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/cursor/SlickLoadCursorException.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/cursor/SlickLoadCursorException.java
@@ -19,26 +19,33 @@ public final class SlickLoadCursorException extends SlickLoadException {
    */
   public SlickLoadCursorException() {
     super();
-  };
+  }
 
   /**
    * Create the exception with an attached message and without parent Throwable.
+   *
+   * @param msg The message that is attached to this exception
    */
   public SlickLoadCursorException(final String msg) {
     super(msg);
-  };
+  }
 
   /**
    * Create the exception with an attached message and parent Throwable.
+   *
+   * @param msg The message that is attached to this exception
+   * @param e The throwable that caused this exception
    */
   public SlickLoadCursorException(final String msg, final Throwable e) {
     super(msg, e);
-  };
+  }
 
   /**
    * Create the exception without an attached message and with parent Throwable.
+   *
+   * @param e The throwable that caused this exception
    */
   public SlickLoadCursorException(final Throwable e) {
     super(e);
-  };
+  }
 }

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/cursor/SlickMouseCursor.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/cursor/SlickMouseCursor.java
@@ -1,14 +1,13 @@
 package de.lessvoid.nifty.slick2d.render.cursor;
 
+import de.lessvoid.nifty.spi.render.MouseCursor;
 import org.newdawn.slick.GameContainer;
 import org.newdawn.slick.Graphics;
 
-import de.lessvoid.nifty.spi.render.MouseCursor;
-
 /**
- * The extended mouse cursor interface that adds the functions needed to handle
- * the mouse cursor by the Slick render device.
- * 
+ * The extended mouse cursor interface that adds the functions needed to handle the mouse cursor by the Slick render
+ * device.
+ *
  * @author Martin Karing &lt;nitram@illarion.org&gt;
  */
 public interface SlickMouseCursor extends MouseCursor {
@@ -27,10 +26,9 @@ public interface SlickMouseCursor extends MouseCursor {
   void enableCursor(GameContainer container);
 
   /**
-   * Render the mouse cursor on the screen. This method is called after every
-   * render loop, how ever in case the mouse cursor uses a native
-   * implementation, its not needed to do anything in this function.
-   * 
+   * Render the mouse cursor on the screen. This method is called after every render loop, how ever in case the mouse
+   * cursor uses a native implementation, its not needed to do anything in this function.
+   *
    * @param g the graphics object that should be used to render
    * @param x the x coordinate of the mouse
    * @param y the y coordinate of the mouse

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/cursor/SlickMouseCursor.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/cursor/SlickMouseCursor.java
@@ -14,11 +14,15 @@ import de.lessvoid.nifty.spi.render.MouseCursor;
 public interface SlickMouseCursor extends MouseCursor {
   /**
    * Stop showing this mouse cursor
+   *
+   * @param container the game container that is supposed to display the default cursor now
    */
   void disableCursor(GameContainer container);
 
   /**
    * Start showing this mouse cursor.
+   *
+   * @param container the game container that is now supposed to show this cursor
    */
   void enableCursor(GameContainer container);
 
@@ -27,12 +31,9 @@ public interface SlickMouseCursor extends MouseCursor {
    * render loop, how ever in case the mouse cursor uses a native
    * implementation, its not needed to do anything in this function.
    * 
-   * @param g
-   *          the graphics object that should be used to render
-   * @param x
-   *          the x coordinate of the mouse
-   * @param y
-   *          the y coordinate of the mouse
+   * @param g the graphics object that should be used to render
+   * @param x the x coordinate of the mouse
+   * @param y the y coordinate of the mouse
    */
   void render(Graphics g, int x, int y);
 }

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/cursor/loader/LwjglCursorSlickMouseCursorLoader.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/cursor/loader/LwjglCursorSlickMouseCursorLoader.java
@@ -1,20 +1,20 @@
 package de.lessvoid.nifty.slick2d.render.cursor.loader;
 
+import org.lwjgl.LWJGLException;
+
 import java.io.IOException;
 
+import de.lessvoid.nifty.slick2d.render.cursor.LwjglCursorSlickMouseCursor;
+import de.lessvoid.nifty.slick2d.render.cursor.SlickLoadCursorException;
+import de.lessvoid.nifty.slick2d.render.cursor.SlickMouseCursor;
 import org.newdawn.slick.opengl.CursorLoader;
 import org.newdawn.slick.opengl.ImageDataFactory;
 import org.newdawn.slick.opengl.LoadableImageData;
 import org.newdawn.slick.util.ResourceLoader;
 
-import de.lessvoid.nifty.slick2d.render.cursor.LwjglCursorSlickMouseCursor;
-import de.lessvoid.nifty.slick2d.render.cursor.SlickLoadCursorException;
-import de.lessvoid.nifty.slick2d.render.cursor.SlickMouseCursor;
-
 /**
- * This loader is used to load slick mouse cursors that work with LWJGL mouse
- * cursors.
- * 
+ * This loader is used to load slick mouse cursors that work with LWJGL mouse cursors.
+ *
  * @author Martin Karing &lt;nitram@illarion.org&gt;
  */
 public final class LwjglCursorSlickMouseCursorLoader implements SlickMouseCursorLoader {
@@ -23,8 +23,8 @@ public final class LwjglCursorSlickMouseCursorLoader implements SlickMouseCursor
    * Load a new mouse cursor.
    */
   @Override
-  public SlickMouseCursor loadCursor(final String filename, final int hotspotX, final int hotspotY)
-      throws SlickLoadCursorException {
+  public SlickMouseCursor loadCursor(
+      final String filename, final int hotspotX, final int hotspotY) throws SlickLoadCursorException {
 
     final LoadableImageData data = ImageDataFactory.getImageDataFor(filename);
     try {
@@ -33,9 +33,11 @@ public final class LwjglCursorSlickMouseCursorLoader implements SlickMouseCursor
       throw new SlickLoadCursorException("Failed loading cursor.", e);
     }
     try {
-      return new LwjglCursorSlickMouseCursor(CursorLoader.get().getCursor(data, hotspotX,
-          (data.getHeight() - hotspotY) + 1));
-    } catch (final Exception e) {
+      return new LwjglCursorSlickMouseCursor(
+          CursorLoader.get().getCursor(data, hotspotX, (data.getHeight() - hotspotY) + 1));
+    } catch (final LWJGLException e) {
+      throw new SlickLoadCursorException("Failed loading cursor.", e);
+    } catch (final IOException e) {
       throw new SlickLoadCursorException("Failed loading cursor.", e);
     }
   }

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/cursor/loader/SlickMouseCursorLoader.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/cursor/loader/SlickMouseCursorLoader.java
@@ -6,22 +6,18 @@ import de.lessvoid.nifty.slick2d.render.cursor.SlickMouseCursor;
 
 /**
  * This interface defines the loader of a mouse cursor.
- * 
+ *
  * @author Martin Karing &lt;nitram@illarion.org&gt;
  */
 public interface SlickMouseCursorLoader extends SlickLoader {
   /**
    * Load a mouse cursor.
-   * 
-   * @param filename
-   *          the name of the file that stores the cursor image
-   * @param hotspotX
-   *          the x coordinate of the hotspot (left->right)
-   * @param hotspotY
-   *          the y coordinate of the hotspot (bottom->top)
+   *
+   * @param filename the name of the file that stores the cursor image
+   * @param hotspotX the x coordinate of the hotspot (left->right)
+   * @param hotspotY the y coordinate of the hotspot (bottom->top)
    * @return the loaded mouse cursor
-   * @throws SlickLoadCursorException
-   *           in case loading the cursor fails
+   * @throws SlickLoadCursorException in case loading the cursor fails
    */
   SlickMouseCursor loadCursor(String filename, int hotspotX, int hotspotY) throws SlickLoadCursorException;
 }

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/font/AbstractJavaSlickRenderFont.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/font/AbstractJavaSlickRenderFont.java
@@ -26,7 +26,7 @@ public abstract class AbstractJavaSlickRenderFont extends AbstractSlickRenderFon
   /**
    * The constructor to create this java AWT based render font.
    * 
-   * @param ttFont
+   * @param slickFont
    *          the true type font that is used to render
    * @param javaFont
    *          the java font that is used to render just the same font

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/font/AbstractJavaSlickRenderFont.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/font/AbstractJavaSlickRenderFont.java
@@ -2,55 +2,54 @@ package de.lessvoid.nifty.slick2d.render.font;
 
 import java.awt.font.GlyphVector;
 
+import org.newdawn.slick.Font;
 import org.newdawn.slick.font.GlyphPage;
 
 /**
- * This class extends the usual abstract slick render font to support fonts that
- * base on Java AWT fonts.
- * 
+ * This class extends the usual abstract slick render font to support fonts that base on Java AWT fonts.
+ *
  * @author Martin Karing &lt;nitram@illarion.org&gt;
  */
 public abstract class AbstractJavaSlickRenderFont extends AbstractSlickRenderFont {
   /**
-   * The java font that is used to get the font data that is needed to render
-   * the font.
+   * The java font that is used to get the font data that is needed to render the font.
    */
   private final java.awt.Font internalFont;
 
   /**
-   * This temporary array is needed to calculate the advancing values in a fast
-   * and easy way.
+   * This temporary array is needed to calculate the advancing values in a fast and easy way.
    */
   private final char[] tempCharArray;
 
   /**
    * The constructor to create this java AWT based render font.
-   * 
-   * @param slickFont
-   *          the true type font that is used to render
-   * @param javaFont
-   *          the java font that is used to render just the same font
-   * @throws SlickLoadFontException
-   *           in case loading the font fails
+   *
+   * @param slickFont the true type font that is used to render
+   * @param javaFont the java font that is used to render just the same font
+   * @throws SlickLoadFontException in case loading the font fails
    */
-  protected AbstractJavaSlickRenderFont(final org.newdawn.slick.Font slickFont, final java.awt.Font javaFont)
-      throws SlickLoadFontException {
+  protected AbstractJavaSlickRenderFont(
+      final Font slickFont, final java.awt.Font javaFont) throws SlickLoadFontException {
     super(slickFont);
     internalFont = javaFont;
     tempCharArray = new char[2];
   }
 
   /**
-   * This function implements a faster method to calculate the advancing from
-   * one character to another compared to the default implementation. Its
-   * optimized to use the Java AWT font implementation.
+   * This function implements a faster method to calculate the advancing from one character to another compared to the
+   * default implementation. Its optimized to use the Java AWT font implementation.
    */
+  @SuppressWarnings("RefusedBequest")
   @Override
   public int getCharacterAdvance(final char currentCharacter, final char nextCharacter, final float size) {
     tempCharArray[0] = currentCharacter;
     tempCharArray[1] = nextCharacter;
 
     final GlyphVector vector = internalFont.createGlyphVector(GlyphPage.renderContext, tempCharArray);
-    return (int) ((vector.getGlyphPosition(1).getX() - vector.getGlyphPosition(0).getX()) * size);
+    final double glyphOffset = vector.getGlyphPosition(1).getX() - vector.getGlyphPosition(0).getX();
+    final long advanceValue = Math.round(glyphOffset * size);
+
+    //noinspection NumericCastThatLosesPrecision
+    return (advanceValue < Integer.MAX_VALUE) ? (int) advanceValue : Integer.MAX_VALUE;
   }
 }

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/font/AbstractSlickRenderFont.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/font/AbstractSlickRenderFont.java
@@ -3,28 +3,25 @@ package de.lessvoid.nifty.slick2d.render.font;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import de.lessvoid.nifty.slick2d.render.SlickRenderUtils;
+import de.lessvoid.nifty.tools.Color;
 import org.newdawn.slick.Font;
 import org.newdawn.slick.Graphics;
 
-import de.lessvoid.nifty.slick2d.render.SlickRenderUtils;
-import de.lessvoid.nifty.tools.Color;
-
 /**
- * This abstract slick render font implements the functions all the other font
- * implementations will share.
- * 
+ * This abstract slick render font implements the functions all the other font implementations will share.
+ *
  * @author Martin Karing &lt;nitram@illarion.org&gt;
  */
 public abstract class AbstractSlickRenderFont implements SlickRenderFont {
   /**
-   * This pattern contains the regular expression to detect color changes within
-   * the text.
+   * This pattern contains the regular expression to detect color changes within the text.
    */
   private final Pattern colorChangePattern;
 
   /**
-   * This instance of the slick color is used to convert the color of Nifty to
-   * slick without creating new objects over and over again.
+   * This instance of the slick color is used to convert the color of Nifty to slick without creating new objects over
+   * and over again.
    */
   private final org.newdawn.slick.Color convertColor;
 
@@ -35,23 +32,22 @@ public abstract class AbstractSlickRenderFont implements SlickRenderFont {
 
   /**
    * Create this render font and define the internal used font.
-   * 
-   * @param font
-   *          the font that supplies the render font with information
+   *
+   * @param font the font that supplies the render font with information
    * @throws SlickLoadFontException in case loading the font fails
    */
   protected AbstractSlickRenderFont(final Font font) throws SlickLoadFontException {
     if (font == null) {
-      throw new SlickLoadFontException();
+      throw new SlickLoadFontException("Font to load was NULL.");
     }
     internalFont = font;
-    convertColor = new org.newdawn.slick.Color(0.f, 0.f, 0.f, 0.f);
-    colorChangePattern = Pattern.compile("\\\\(#\\p{XDigit}{3,8})#");
+    convertColor = new org.newdawn.slick.Color(0.0f, 0.0f, 0.0f, 0.0f);
+    colorChangePattern = Pattern.compile("\\\\(#\\p{XDigit}{3,8})#"); //NON-NLS
   }
 
   /**
    * {@inheritDoc}
-   * 
+   * <p/>
    * Overwrite this method in case you need to dispose the font data.
    */
   @Override
@@ -61,47 +57,35 @@ public abstract class AbstractSlickRenderFont implements SlickRenderFont {
 
   /**
    * {@inheritDoc}
-   * 
-   * This implementation is very crappy. In case a better way is found for any
-   * special font type, this method should be overwritten.
+   * <p/>
+   * This implementation is very crappy. In case a better way is found for any special font type, this method should be
+   * overwritten.
    */
   @Override
   public int getCharacterAdvance(final char currentCharacter, final char nextCharacter, final float size) {
     // this is a ugly implementation, but I failed to come up with anything
     // better...
     final int firstLength = internalFont.getWidth(Character.toString(currentCharacter));
-    final int secondLength = internalFont.getWidth(Character.toString(currentCharacter)
-        + Character.toString(nextCharacter));
-    return (int) ((secondLength - firstLength) * size);
+    final int secondLength = internalFont.getWidth(
+        Character.toString(currentCharacter) + Character.toString(nextCharacter));
+    return Math.round((secondLength - firstLength) * size);
   }
 
-  /**
-   * {@inheritDoc}
-   */
   @Override
   public final int getHeight() {
     return internalFont.getLineHeight();
   }
 
-  /**
-   * {@inheritDoc}
-   */
   @Override
   public final int getWidth(final String text) {
     return internalFont.getWidth(getCleanedString(text));
   }
 
-  /**
-   * {@inheritDoc}
-   */
   @Override
   public final int getWidth(final String text, final float size) {
-    return (int) (getWidth(text) * size);
+    return Math.round(getWidth(text) * size);
   }
 
-  /**
-   * {@inheritDoc}
-   */
   @Override
   public final void renderText(
       final Graphics g,
@@ -120,7 +104,7 @@ public abstract class AbstractSlickRenderFont implements SlickRenderFont {
       renderTextImpl(g, text, locX, locY, color, sizeX, sizeY);
       return;
     }
-    
+
     final int maximumLineHeight = internalFont.getHeight(getCleanedString(text));
 
     Color currentColor = color;
@@ -129,8 +113,8 @@ public abstract class AbstractSlickRenderFont implements SlickRenderFont {
 
     do {
       final int lastIndex = patternMatcher.start() - 1;
-      
-      String textPart;
+
+      final String textPart;
       if (lastIndex > -1) {
         textPart = text.substring(nextTextIndex, lastIndex);
         final int currentY = locY + (maximumLineHeight - internalFont.getHeight(textPart));
@@ -142,15 +126,12 @@ public abstract class AbstractSlickRenderFont implements SlickRenderFont {
       nextTextIndex = patternMatcher.end();
       // get the new color
       final String colorText = patternMatcher.group(1);
-      if (Color.check(colorText)) {
-        currentColor = new Color(colorText);
-      } else {
-        currentColor = color;
-      }
+      currentColor = Color.check(colorText) ? new Color(colorText) : color;
       // get the new location
 
       if (lastIndex > -1) {
-        currentX += getWidth(textPart, sizeX) + getCharacterAdvance(text.charAt(lastIndex), text.charAt(nextTextIndex), sizeX);
+        currentX += getWidth(textPart, sizeX) + getCharacterAdvance(text.charAt(lastIndex), text.charAt(nextTextIndex),
+            sizeX);
       }
     } while (patternMatcher.find());
 
@@ -160,20 +141,20 @@ public abstract class AbstractSlickRenderFont implements SlickRenderFont {
       renderTextImpl(g, textPart, currentX, currentY, currentColor, sizeX, sizeY);
     }
   }
-  
+
   /**
    * Clean all color change markers from the text.
-   * 
+   *
    * @param orgString the original text
    * @return the cleaned text
    */
-  private String getCleanedString(final String orgString) {
+  private String getCleanedString(final CharSequence orgString) {
     return colorChangePattern.matcher(orgString).replaceAll("");
   }
 
   /**
    * This function contains the actual text rendering implementation.
-   * 
+   *
    * @param g the graphics object used to drawn
    * @param text the text to draw
    * @param locX the x coordinate of the screen location to drawn on

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/font/AbstractSlickRenderFont.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/font/AbstractSlickRenderFont.java
@@ -37,7 +37,8 @@ public abstract class AbstractSlickRenderFont implements SlickRenderFont {
    * Create this render font and define the internal used font.
    * 
    * @param font
-   *          the font that supplies the render font with informations
+   *          the font that supplies the render font with information
+   * @throws SlickLoadFontException in case loading the font fails
    */
   protected AbstractSlickRenderFont(final Font font) throws SlickLoadFontException {
     if (font == null) {

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/font/AbstractSlickRenderFont.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/font/AbstractSlickRenderFont.java
@@ -63,8 +63,7 @@ public abstract class AbstractSlickRenderFont implements SlickRenderFont {
    */
   @Override
   public int getCharacterAdvance(final char currentCharacter, final char nextCharacter, final float size) {
-    // this is a ugly implementation, but I failed to come up with anything
-    // better...
+    // this is a ugly implementation, but I failed to come up with anything better...
     final int firstLength = internalFont.getWidth(Character.toString(currentCharacter));
     final int secondLength = internalFont.getWidth(
         Character.toString(currentCharacter) + Character.toString(nextCharacter));
@@ -99,45 +98,45 @@ public abstract class AbstractSlickRenderFont implements SlickRenderFont {
     final Matcher patternMatcher = colorChangePattern.matcher(text);
 
     if (!patternMatcher.find()) {
-      // The color change thingy was not found. So we can just write the entire
-      // text and be done with it.
+      // The color change thingy was not found. So we can just write the entire text and be done with it.
       renderTextImpl(g, text, locX, locY, color, sizeX, sizeY);
       return;
     }
 
-    final int maximumLineHeight = internalFont.getHeight(getCleanedString(text));
+    final int maximumLineHeight = Math.round(internalFont.getHeight(getCleanedString(text)) * sizeY);
 
     Color currentColor = color;
-    int nextTextIndex = 0;
     int currentX = locX;
 
+
+    int lastProcessedChar = -1;
+
     do {
-      final int lastIndex = patternMatcher.start() - 1;
+      final int firstColorIndex = patternMatcher.start();
 
       final String textPart;
-      if (lastIndex > -1) {
-        textPart = text.substring(nextTextIndex, lastIndex);
-        final int currentY = locY + (maximumLineHeight - internalFont.getHeight(textPart));
+      if ((firstColorIndex - lastProcessedChar) > 1) {
+        textPart = text.substring(lastProcessedChar + 1, firstColorIndex);
+        final int currentY = locY + Math.round((maximumLineHeight - internalFont.getHeight(textPart)) * sizeY);
         renderTextImpl(g, textPart, currentX, currentY, currentColor, sizeX, sizeY);
       } else {
         textPart = "";
       }
 
-      nextTextIndex = patternMatcher.end();
+      lastProcessedChar = patternMatcher.end() - 1;
       // get the new color
       final String colorText = patternMatcher.group(1);
       currentColor = Color.check(colorText) ? new Color(colorText) : color;
       // get the new location
 
-      if (lastIndex > -1) {
-        currentX += getWidth(textPart, sizeX) + getCharacterAdvance(text.charAt(lastIndex), text.charAt(nextTextIndex),
-            sizeX);
+      if (!textPart.isEmpty()) {
+        currentX += getWidth(textPart, sizeX);
       }
     } while (patternMatcher.find());
 
-    if (text.length() >= nextTextIndex) {
-      final String textPart = text.substring(nextTextIndex);
-      final int currentY = locY + (maximumLineHeight - internalFont.getHeight(textPart));
+    if (text.length() >= (lastProcessedChar + 2)) {
+      final String textPart = text.substring(lastProcessedChar + 1);
+      final int currentY = locY + Math.round((maximumLineHeight - internalFont.getHeight(textPart)) * sizeY);
       renderTextImpl(g, textPart, currentX, currentY, currentColor, sizeX, sizeY);
     }
   }

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/font/AngelCodeSlickRenderFont.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/font/AngelCodeSlickRenderFont.java
@@ -3,20 +3,18 @@ package de.lessvoid.nifty.slick2d.render.font;
 import org.newdawn.slick.AngelCodeFont;
 
 /**
- * This is the render font implementation that uses an angel code font to render
- * the text.
- * 
+ * This is the render font implementation that uses an angel code font to render the text.
+ *
  * @author Martin Karing &lt;nitram@illarion.org&gt;
  */
 public class AngelCodeSlickRenderFont extends AbstractSlickRenderFont {
   /**
    * Create the render font using a already loaded angel code font.
-   * 
-   * @param font
-   *          the font this render font is supposed to encapsulate
-   * @throws SlickLoadFontException
-   *           in case loading the font fails
+   *
+   * @param font the font this render font is supposed to encapsulate
+   * @throws SlickLoadFontException in case loading the font fails
    */
+  @SuppressWarnings("TypeMayBeWeakened")
   public AngelCodeSlickRenderFont(final AngelCodeFont font) throws SlickLoadFontException {
     super(font);
   }

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/font/DefaultSlickRenderFont.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/font/DefaultSlickRenderFont.java
@@ -3,19 +3,16 @@ package de.lessvoid.nifty.slick2d.render.font;
 import org.newdawn.slick.Font;
 
 /**
- * This is the render font implementation that uses an unknown font
- * implementation.
- * 
+ * This is the render font implementation that uses an unknown font implementation.
+ *
  * @author Martin Karing &lt;nitram@illarion.org&gt;
  */
 public class DefaultSlickRenderFont extends AbstractSlickRenderFont {
   /**
    * Create the render font using a already loaded font.
-   * 
-   * @param font
-   *          the font this render font is supposed to encapsulate
-   * @throws SlickLoadFontException
-   *           in case loading the font fails
+   *
+   * @param font the font this render font is supposed to encapsulate
+   * @throws SlickLoadFontException in case loading the font fails
    */
   public DefaultSlickRenderFont(final Font font) throws SlickLoadFontException {
     super(font);

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/font/SlickLoadFontException.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/font/SlickLoadFontException.java
@@ -3,9 +3,8 @@ package de.lessvoid.nifty.slick2d.render.font;
 import de.lessvoid.nifty.slick2d.loaders.SlickLoadException;
 
 /**
- * This exception is expected to be thrown be the constructor of this class in
- * case loading the specified font failed.
- * 
+ * This exception is expected to be thrown be the constructor of this class in case loading the specified font failed.
+ *
  * @author Martin Karing &lt;nitram@illarion.org&gt;
  */
 public final class SlickLoadFontException extends SlickLoadException {
@@ -18,7 +17,6 @@ public final class SlickLoadFontException extends SlickLoadException {
    * Create the exception without an attached message or parent Throwable.
    */
   public SlickLoadFontException() {
-    super();
   }
 
   /**

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/font/SlickLoadFontException.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/font/SlickLoadFontException.java
@@ -19,26 +19,33 @@ public final class SlickLoadFontException extends SlickLoadException {
    */
   public SlickLoadFontException() {
     super();
-  };
+  }
 
   /**
    * Create the exception with an attached message and without parent Throwable.
+   *
+   * @param msg The message that is attached to this exception
    */
   public SlickLoadFontException(final String msg) {
     super(msg);
-  };
+  }
 
   /**
    * Create the exception with an attached message and parent Throwable.
+   *
+   * @param msg The message that is attached to this exception
+   * @param e The throwable that caused this exception
    */
   public SlickLoadFontException(final String msg, final Throwable e) {
     super(msg, e);
-  };
+  }
 
   /**
    * Create the exception without an attached message and with parent Throwable.
+   *
+   * @param e The throwable that caused this exception
    */
   public SlickLoadFontException(final Throwable e) {
     super(e);
-  };
+  }
 }

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/font/SlickRenderFont.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/font/SlickRenderFont.java
@@ -1,39 +1,28 @@
 package de.lessvoid.nifty.slick2d.render.font;
 
-import org.newdawn.slick.Graphics;
-
 import de.lessvoid.nifty.spi.render.RenderFont;
 import de.lessvoid.nifty.tools.Color;
+import org.newdawn.slick.Graphics;
 
 /**
- * This interface extends the normal Nifty
- * {@link de.lessvoid.nifty.spi.render.RenderFont} to make it usable with the
- * render device of this Slick renderer.
- * 
+ * This interface extends the normal Nifty {@link RenderFont} to make it usable with the render device of this Slick
+ * renderer.
+ *
  * @author Martin Karing &lt;nitram@illarion.org&gt;
  */
 public interface SlickRenderFont extends RenderFont {
   /**
    * Render a text using this font.
-   * 
-   * @param g
-   *          the slick graphics object that is used to render
-   * @param text
-   *          the text that is supposed to be rendered
-   * @param locX
-   *          the x coordinate of the position on the screen where the text is
-   *          supposed to be rendered
-   * @param locY
-   *          the y coordinate of the position on the screen where the text is
-   *          supposed to be rendered
-   * @param color
-   *          the color of the text
-   * @param sizeX
-   *          the horizontal scaling factor of the text
-   * @param sizeY
-   *          the vertical scaling factor of the text
-   * @throws IllegalArgumentException
-   *           in case the parameter g is <code>null</code> or in case the parameter text is <code>null</code>
+   *
+   * @param g the slick graphics object that is used to render
+   * @param text the text that is supposed to be rendered
+   * @param locX the x coordinate of the position on the screen where the text is supposed to be rendered
+   * @param locY the y coordinate of the position on the screen where the text is supposed to be rendered
+   * @param color the color of the text
+   * @param sizeX the horizontal scaling factor of the text
+   * @param sizeY the vertical scaling factor of the text
+   * @throws IllegalArgumentException in case the parameter g is {@code null} or in case the parameter text is {@code
+   * null}
    */
   void renderText(Graphics g, String text, int locX, int locY, Color color, float sizeX, float sizeY);
 }

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/font/SlickRenderFont.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/font/SlickRenderFont.java
@@ -33,9 +33,7 @@ public interface SlickRenderFont extends RenderFont {
    * @param sizeY
    *          the vertical scaling factor of the text
    * @throws IllegalArgumentException
-   *           in case the parameter g is <code>null</code>
-   * @throws IllegalArgumentException
-   *           in case the parameter text is <code>null</code>
+   *           in case the parameter g is <code>null</code> or in case the parameter text is <code>null</code>
    */
   void renderText(Graphics g, String text, int locX, int locY, Color color, float sizeX, float sizeY);
 }

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/font/TrueTypeSlickRenderFont.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/font/TrueTypeSlickRenderFont.java
@@ -1,30 +1,26 @@
 package de.lessvoid.nifty.slick2d.render.font;
 
-import java.awt.Font;
-
-import org.newdawn.slick.TrueTypeFont;
+import java.awt.*;
 
 /**
- * This is the render font implementation that uses an true type font to render
- * the text.
- * 
+ * This is the render font implementation that uses an true type font to render the text.
+ *
  * @author Martin Karing &lt;nitram@illarion.org&gt;
- * @deprecated This font uses the {@link org.newdawn.slick.TrueTypeFont} that is
- *             marked as deprecated
+ * @deprecated This font uses the {@link org.newdawn.slick.TrueTypeFont} that is marked as deprecated
  */
+@SuppressWarnings("UnnecessaryFullyQualifiedName")
 @Deprecated
 public class TrueTypeSlickRenderFont extends AbstractJavaSlickRenderFont {
   /**
    * The constructor to create this true type based render font.
-   * 
-   * @param ttFont
-   *          the true type font that is used to render
-   * @param javaFont
-   *          the java font that is used to render just the same font
-   * @throws SlickLoadFontException
-   *           in case loading the font fails
+   *
+   * @param ttFont the true type font that is used to render
+   * @param javaFont the java font that is used to render just the same font
+   * @throws SlickLoadFontException in case loading the font fails
    */
-  public TrueTypeSlickRenderFont(final TrueTypeFont ttFont, final Font javaFont) throws SlickLoadFontException {
+  public TrueTypeSlickRenderFont(
+      @SuppressWarnings("TypeMayBeWeakened") final org.newdawn.slick.TrueTypeFont ttFont,
+      final Font javaFont) throws SlickLoadFontException {
     super(ttFont, javaFont);
   }
 }

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/font/UnicodeSlickRenderFont.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/font/UnicodeSlickRenderFont.java
@@ -1,26 +1,22 @@
 package de.lessvoid.nifty.slick2d.render.font;
 
-import java.awt.Font;
+import java.awt.*;
 
 import org.newdawn.slick.SlickException;
 import org.newdawn.slick.UnicodeFont;
 
 /**
- * This render font implementation uses a unicode font to draw the text on the
- * screen.
- * 
+ * This render font implementation uses a unicode font to draw the text on the screen.
+ *
  * @author Martin Karing &lt;nitram@illarion.org&gt;
  */
 public class UnicodeSlickRenderFont extends AbstractJavaSlickRenderFont {
   /**
    * The constructor to create this unicode font based render font.
-   * 
-   * @param ucFont
-   *          the unicode font that is used to render
-   * @param javaFont
-   *          the java font that is used to render just the same font
-   * @throws SlickLoadFontException
-   *           in case loading the font fails
+   *
+   * @param ucFont the unicode font that is used to render
+   * @param javaFont the java font that is used to render just the same font
+   * @throws SlickLoadFontException in case loading the font fails
    */
   public UnicodeSlickRenderFont(final UnicodeFont ucFont, final Font javaFont) throws SlickLoadFontException {
     super(ucFont, javaFont);

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/font/loader/AbstractJavaSlickRenderFontLoader.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/font/loader/AbstractJavaSlickRenderFontLoader.java
@@ -1,44 +1,38 @@
 package de.lessvoid.nifty.slick2d.render.font.loader;
 
-import java.awt.Font;
-import java.awt.FontFormatException;
+import java.awt.*;
 import java.io.IOException;
 import java.io.InputStream;
 
 import org.newdawn.slick.util.ResourceLoader;
 
 /**
- * This abstract font loader is used to support loading fonts that base on Java
- * AWT fonts.
- * 
+ * This abstract font loader is used to support loading fonts that base on Java AWT fonts.
+ *
  * @author Martin Karing &lt;nitram@illarion.org&gt;
  */
 public abstract class AbstractJavaSlickRenderFontLoader implements SlickRenderFontLoader {
   /**
-   * Load the file that is named in the String as a Java Font assuming the font
-   * is of the defined type.
-   * 
-   * @param font
-   *          the String that defines the file that should be loaded
-   * @param type
-   *          the font type that is assumed when loading the font
-   * @return the loaded font or <code>null</code> in case loading the font
-   *         failed
+   * Load the file that is named in the String as a Java Font assuming the font is of the defined type.
+   *
+   * @param font the String that defines the file that should be loaded
+   * @param type the font type that is assumed when loading the font
+   * @return the loaded font or {@code null} in case loading the font failed
    */
-  private Font loadFont(final String font, final int type) {
+  private static Font loadFont(final String font, final int type) {
     InputStream fontInStream = null;
     try {
       fontInStream = ResourceLoader.getResourceAsStream(font);
       return Font.createFont(type, fontInStream);
-    } catch (final IOException e) {
+    } catch (final IOException ignored) {
       // IO Problem -> Ignore
-    } catch (final FontFormatException e) {
+    } catch (final FontFormatException ignored) {
       // not true type -> does not matter, more methods to try
     } finally {
       if (fontInStream != null) {
         try {
           fontInStream.close();
-        } catch (final IOException e) {
+        } catch (final IOException ignored) {
           // Closing the stream failed -> no one cares
         }
       }
@@ -48,16 +42,12 @@ public abstract class AbstractJavaSlickRenderFontLoader implements SlickRenderFo
   }
 
   /**
-   * Try loading the file defined with the String as a Java font on any way
-   * possible.
-   * 
-   * @param font
-   *          the String that defines the file that is supposed to be load as
-   *          font
-   * @return the loaded font or <code>null</code> in case loading the font
-   *         failed
+   * Try loading the file defined with the String as a Java font on any way possible.
+   *
+   * @param font the String that defines the file that is supposed to be load as font
+   * @return the loaded font or {@code null} in case loading the font failed
    */
-  protected final Font loadJavaFont(final String font) {
+  protected static Font loadJavaFont(final String font) {
     Font javaFont = loadFont(font, Font.TRUETYPE_FONT);
     if (javaFont == null) {
       javaFont = loadFont(font, Font.TYPE1_FONT);

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/font/loader/AngelCodeSlickRenderFontLoader.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/font/loader/AngelCodeSlickRenderFontLoader.java
@@ -18,11 +18,10 @@ public final class AngelCodeSlickRenderFontLoader implements SlickRenderFontLoad
    */
   @Override
   public SlickRenderFont loadFont(final Graphics g, final String filename) throws SlickLoadFontException {
-    final String image = filename;
     final String definition = filename.substring(0, filename.lastIndexOf('.') + 1) + "fnt";
 
     try {
-      return new AngelCodeSlickRenderFont(new AngelCodeFont(image, definition));
+      return new AngelCodeSlickRenderFont(new AngelCodeFont(filename, definition));
     } catch (final Exception e) {
       throw new SlickLoadFontException("Loading font failed.", e);
     }

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/font/loader/AngelCodeSlickRenderFontLoader.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/font/loader/AngelCodeSlickRenderFontLoader.java
@@ -1,15 +1,15 @@
 package de.lessvoid.nifty.slick2d.render.font.loader;
 
-import org.newdawn.slick.AngelCodeFont;
-import org.newdawn.slick.Graphics;
-
 import de.lessvoid.nifty.slick2d.render.font.AngelCodeSlickRenderFont;
 import de.lessvoid.nifty.slick2d.render.font.SlickLoadFontException;
 import de.lessvoid.nifty.slick2d.render.font.SlickRenderFont;
+import org.newdawn.slick.AngelCodeFont;
+import org.newdawn.slick.Graphics;
+import org.newdawn.slick.SlickException;
 
 /**
  * The loader is able to load render fonts that are based on angel code fonts.
- * 
+ *
  * @author Martin Karing &lt;nitram@illarion.org&gt;
  */
 public final class AngelCodeSlickRenderFontLoader implements SlickRenderFontLoader {
@@ -22,7 +22,9 @@ public final class AngelCodeSlickRenderFontLoader implements SlickRenderFontLoad
 
     try {
       return new AngelCodeSlickRenderFont(new AngelCodeFont(filename, definition));
-    } catch (final Exception e) {
+    } catch (final SlickLoadFontException e) {
+      throw new SlickLoadFontException("Loading font failed.", e);
+    } catch (final SlickException e) {
       throw new SlickLoadFontException("Loading font failed.", e);
     }
   }

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/font/loader/DefaultSlickRenderFontLoader.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/font/loader/DefaultSlickRenderFontLoader.java
@@ -1,14 +1,13 @@
 package de.lessvoid.nifty.slick2d.render.font.loader;
 
-import org.newdawn.slick.Graphics;
-
 import de.lessvoid.nifty.slick2d.render.font.DefaultSlickRenderFont;
 import de.lessvoid.nifty.slick2d.render.font.SlickLoadFontException;
 import de.lessvoid.nifty.slick2d.render.font.SlickRenderFont;
+import org.newdawn.slick.Graphics;
 
 /**
  * The loader is able to load the default render font
- * 
+ *
  * @author Martin Karing &lt;nitram@illarion.org&gt;
  */
 public final class DefaultSlickRenderFontLoader implements SlickRenderFontLoader {
@@ -20,7 +19,7 @@ public final class DefaultSlickRenderFontLoader implements SlickRenderFontLoader
     try {
       g.resetFont();
       return new DefaultSlickRenderFont(g.getFont());
-    } catch (final Exception e) {
+    } catch (final SlickLoadFontException e) {
       throw new SlickLoadFontException("Loading font failed.", e);
     }
   }

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/font/loader/HieroUnicodeSlickRenderFontLoader.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/font/loader/HieroUnicodeSlickRenderFontLoader.java
@@ -1,27 +1,24 @@
 package de.lessvoid.nifty.slick2d.render.font.loader;
 
-import java.awt.Font;
+import java.awt.*;
 
+import de.lessvoid.nifty.slick2d.render.font.SlickLoadFontException;
+import de.lessvoid.nifty.slick2d.render.font.SlickRenderFont;
+import de.lessvoid.nifty.slick2d.render.font.UnicodeSlickRenderFont;
 import org.newdawn.slick.Graphics;
 import org.newdawn.slick.SlickException;
 import org.newdawn.slick.UnicodeFont;
 import org.newdawn.slick.font.HieroSettings;
 
-import de.lessvoid.nifty.slick2d.render.font.SlickLoadFontException;
-import de.lessvoid.nifty.slick2d.render.font.SlickRenderFont;
-import de.lessvoid.nifty.slick2d.render.font.UnicodeSlickRenderFont;
-
 /**
- * Load the font as Unicode font using Hiero settings to specify how the font is
- * supposed to look like.
- * 
+ * Load the font as Unicode font using Hiero settings to specify how the font is supposed to look like.
+ *
  * @author Martin Karing &lt;nitram@illarion.org&gt;
  */
 public final class HieroUnicodeSlickRenderFontLoader extends AbstractJavaSlickRenderFontLoader {
   /**
-   * Load the font. The name of the font will be used as name of the Hiero
-   * settings file. The true type font file will be load by trying to add ".ttf"
-   * to the filename and by replacing the file ending with "ttf".
+   * Load the font. The name of the font will be used as name of the Hiero settings file. The true type font file will
+   * be load by trying to add ".ttf" to the filename and by replacing the file ending with "ttf".
    */
   @Override
   public SlickRenderFont loadFont(final Graphics g, final String filename) throws SlickLoadFontException {
@@ -32,7 +29,7 @@ public final class HieroUnicodeSlickRenderFontLoader extends AbstractJavaSlickRe
       if (javaFont == null) {
         throw new SlickLoadFontException("Loading TTF Font failed.");
       }
-      
+
       final UnicodeFont uniFont = new UnicodeFont(javaFont, hieroSettings);
       uniFont.addAsciiGlyphs();
 
@@ -46,20 +43,16 @@ public final class HieroUnicodeSlickRenderFontLoader extends AbstractJavaSlickRe
 
   /**
    * Try to located the font using the filename and common naming conversations.
-   * 
-   * @param filename
-   *          the filename of the font
-   * @return the loaded font or <code>null</code>
+   *
+   * @param filename the filename of the font
+   * @return the loaded font or {@code null}
    */
-  private Font loadFont(final String filename) {
-    Font javaFont;
+  private static Font loadFont(final String filename) {
 
-    javaFont = loadJavaFont(filename.concat(".ttf"));
-    if (javaFont != null) {
-      return javaFont;
+    Font javaFont = loadJavaFont(filename + ".ttf");
+    if (javaFont == null) {
+      javaFont = loadJavaFont(filename.substring(0, filename.lastIndexOf('.')) + "ttf");
     }
-
-    javaFont = loadJavaFont(filename.substring(0, filename.lastIndexOf('.')).concat("ttf"));
 
     return javaFont;
   }

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/font/loader/SlickRenderFontLoader.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/font/loader/SlickRenderFontLoader.java
@@ -1,27 +1,23 @@
 package de.lessvoid.nifty.slick2d.render.font.loader;
 
-import org.newdawn.slick.Graphics;
-
 import de.lessvoid.nifty.slick2d.loaders.SlickLoader;
 import de.lessvoid.nifty.slick2d.render.font.SlickLoadFontException;
 import de.lessvoid.nifty.slick2d.render.font.SlickRenderFont;
+import org.newdawn.slick.Graphics;
 
 /**
  * This interface defines a font loader that loads a font to be used by Nifty.
- * 
+ *
  * @author Martin Karing &lt;nitram@illarion.org&gt;
  */
 public interface SlickRenderFontLoader extends SlickLoader {
   /**
    * Load a render font that is identified by a String.
-   * 
-   * @param g
-   *          the graphics instance used for all render operations
-   * @param filename
-   *          the filename to load
+   *
+   * @param g the graphics instance used for all render operations
+   * @param filename the filename to load
    * @return the loaded font
-   * @throws SlickLoadFontException
-   *           in case loading the font fails
+   * @throws SlickLoadFontException in case loading the font fails
    */
   SlickRenderFont loadFont(Graphics g, String filename) throws SlickLoadFontException;
 }

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/font/loader/TrueTypeSlickRenderFontLoader.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/font/loader/TrueTypeSlickRenderFontLoader.java
@@ -16,11 +16,37 @@ import org.newdawn.slick.Graphics;
 @Deprecated
 public final class TrueTypeSlickRenderFontLoader extends AbstractJavaSlickRenderFontLoader {
   /**
+   * The default size of a font. This value is needed as TrueType fonts in general do not have a default size,
+   * but Nifty expects a font to be rendered at default size.
+   */
+  private static final float DEFAULT_SIZE = 12.0f;
+
+  /**
+   * The font size that will be actually used in case the font does not provide a default size.
+   */
+  private float fontSize;
+
+  /**
+   * Constructor that uses the provided default size of 12pt as font size.
+   */
+  public TrueTypeSlickRenderFontLoader() {
+    this(DEFAULT_SIZE);
+  }
+
+  /**
+   * This constructor allows setting the size all fonts are load with.
+   *
+   * @param defaultSize the new size of the font
+   */
+  public TrueTypeSlickRenderFontLoader(final float defaultSize) {
+    fontSize = defaultSize;
+  }
+  /**
    * Load the requested font.
    */
   @Override
   public SlickRenderFont loadFont(final Graphics g, final String filename) throws SlickLoadFontException {
-    final Font javaFont;
+    Font javaFont;
     try {
       javaFont = loadJavaFont(filename);
     } catch (final Exception e) {
@@ -29,6 +55,8 @@ public final class TrueTypeSlickRenderFontLoader extends AbstractJavaSlickRender
     if (javaFont == null) {
       throw new SlickLoadFontException("Can't load font as true type.");
     }
+
+    javaFont = javaFont.deriveFont(fontSize);
 
     return new de.lessvoid.nifty.slick2d.render.font.TrueTypeSlickRenderFont(
         new org.newdawn.slick.TrueTypeFont(javaFont, true), javaFont);

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/font/loader/TrueTypeSlickRenderFontLoader.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/font/loader/TrueTypeSlickRenderFontLoader.java
@@ -1,21 +1,18 @@
 package de.lessvoid.nifty.slick2d.render.font.loader;
 
-import java.awt.Font;
-
-import org.newdawn.slick.Graphics;
-import org.newdawn.slick.TrueTypeFont;
+import java.awt.*;
 
 import de.lessvoid.nifty.slick2d.render.font.SlickLoadFontException;
 import de.lessvoid.nifty.slick2d.render.font.SlickRenderFont;
-import de.lessvoid.nifty.slick2d.render.font.TrueTypeSlickRenderFont;
+import org.newdawn.slick.Graphics;
 
 /**
  * This loader is able to load fonts that base on TrueType fonts.
- * 
+ *
  * @author Martin Karing &lt;nitram@illarion.org&gt;
- * @deprecated This loader uses the {@link org.newdawn.slick.TrueTypeFont} that
- *             is marked as deprecated
+ * @deprecated This loader uses the {@link org.newdawn.slick.TrueTypeFont} that is marked as deprecated
  */
+@SuppressWarnings("UnnecessaryFullyQualifiedName")
 @Deprecated
 public final class TrueTypeSlickRenderFontLoader extends AbstractJavaSlickRenderFontLoader {
   /**
@@ -23,7 +20,7 @@ public final class TrueTypeSlickRenderFontLoader extends AbstractJavaSlickRender
    */
   @Override
   public SlickRenderFont loadFont(final Graphics g, final String filename) throws SlickLoadFontException {
-    Font javaFont;
+    final Font javaFont;
     try {
       javaFont = loadJavaFont(filename);
     } catch (final Exception e) {
@@ -33,7 +30,8 @@ public final class TrueTypeSlickRenderFontLoader extends AbstractJavaSlickRender
       throw new SlickLoadFontException("Can't load font as true type.");
     }
 
-    return new TrueTypeSlickRenderFont(new TrueTypeFont(javaFont, true), javaFont);
+    return new de.lessvoid.nifty.slick2d.render.font.TrueTypeSlickRenderFont(
+        new org.newdawn.slick.TrueTypeFont(javaFont, true), javaFont);
   }
 
 }

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/font/loader/TrueTypeSlickRenderFontLoader.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/font/loader/TrueTypeSlickRenderFontLoader.java
@@ -17,7 +17,8 @@ import org.newdawn.slick.Graphics;
 public final class TrueTypeSlickRenderFontLoader extends AbstractJavaSlickRenderFontLoader {
   /**
    * The default size of a font. This value is needed as TrueType fonts in general do not have a default size,
-   * but Nifty expects a font to be rendered at default size.
+   * but Nifty
+   * expects a font to be rendered at default size.
    */
   private static final float DEFAULT_SIZE = 12.0f;
 
@@ -41,6 +42,7 @@ public final class TrueTypeSlickRenderFontLoader extends AbstractJavaSlickRender
   public TrueTypeSlickRenderFontLoader(final float defaultSize) {
     fontSize = defaultSize;
   }
+
   /**
    * Load the requested font.
    */

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/font/loader/TrueTypeSlickRenderFontLoader.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/font/loader/TrueTypeSlickRenderFontLoader.java
@@ -23,7 +23,7 @@ public final class TrueTypeSlickRenderFontLoader extends AbstractJavaSlickRender
    */
   @Override
   public SlickRenderFont loadFont(final Graphics g, final String filename) throws SlickLoadFontException {
-    Font javaFont = null;
+    Font javaFont;
     try {
       javaFont = loadJavaFont(filename);
     } catch (final Exception e) {

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/font/loader/UnicodeSlickRenderFontLoader.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/font/loader/UnicodeSlickRenderFontLoader.java
@@ -1,47 +1,51 @@
 package de.lessvoid.nifty.slick2d.render.font.loader;
 
-import java.awt.Font;
-
-import org.newdawn.slick.Graphics;
-import org.newdawn.slick.UnicodeFont;
-import org.newdawn.slick.font.effects.ColorEffect;
+import java.awt.*;
 
 import de.lessvoid.nifty.slick2d.render.font.SlickLoadFontException;
 import de.lessvoid.nifty.slick2d.render.font.SlickRenderFont;
 import de.lessvoid.nifty.slick2d.render.font.UnicodeSlickRenderFont;
+import org.newdawn.slick.Graphics;
+import org.newdawn.slick.UnicodeFont;
+import org.newdawn.slick.font.effects.ColorEffect;
 
 /**
- * Load the font as Unicode font using Hiero settings to specify how the font is
- * supposed to look like.
- * 
+ * Load the font as Unicode font using Hiero settings to specify how the font is supposed to look like.
+ *
  * @author Martin Karing &lt;nitram@illarion.org&gt;
  */
 public final class UnicodeSlickRenderFontLoader extends AbstractJavaSlickRenderFontLoader {
   /**
-   * Load the font. The name of the font will be used as name of the Hiero
-   * settings file. The true type font file will be load by trying to add ".ttf"
-   * to the filename and by replacing the file ending with "ttf".
+   * The default size of a font. This value is needed as TrueType fonts in general do not have a default size,
+   * but Nifty
+   * expects a font to be rendered at default size.
+   */
+  private static final float DEFAULT_SIZE = 12.0f;
+
+  /**
+   * Load the font. The name of the font will be used as name of the Hiero settings file. The true type font file will
+   * be load by trying to add ".ttf" to the filename and by replacing the file ending with "ttf".
    */
   @Override
   @SuppressWarnings("unchecked")
   public SlickRenderFont loadFont(final Graphics g, final String filename) throws SlickLoadFontException {
+    Font javaFont = loadJavaFont(filename);
+
+    if (javaFont == null) {
+      throw new SlickLoadFontException("Loading TTF Font failed.");
+    }
+
+    if (javaFont.getSize() == 1) {
+      javaFont = javaFont.deriveFont(DEFAULT_SIZE);
+    }
+
     try {
-      Font javaFont = loadJavaFont(filename);
-
-      if (javaFont == null) {
-        throw new SlickLoadFontException("Loading TTF Font failed.");
-      }
-      
-      if (javaFont.getSize() == 1) {
-        javaFont = javaFont.deriveFont(12.f);
-      }
-
       final UnicodeFont uniFont = new UnicodeFont(javaFont);
       uniFont.addAsciiGlyphs();
       uniFont.getEffects().add(new ColorEffect());
 
       return new UnicodeSlickRenderFont(uniFont, javaFont);
-    } catch (final Exception e) {
+    } catch (final SlickLoadFontException e) {
       throw new SlickLoadFontException("Loading the font failed.", e);
     }
   }

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/font/loader/UnicodeSlickRenderFontLoader.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/font/loader/UnicodeSlickRenderFontLoader.java
@@ -17,10 +17,30 @@ import org.newdawn.slick.font.effects.ColorEffect;
 public final class UnicodeSlickRenderFontLoader extends AbstractJavaSlickRenderFontLoader {
   /**
    * The default size of a font. This value is needed as TrueType fonts in general do not have a default size,
-   * but Nifty
-   * expects a font to be rendered at default size.
+   * but Nifty expects a font to be rendered at default size.
    */
   private static final float DEFAULT_SIZE = 12.0f;
+
+  /**
+   * The font size that will be actually used in case the font does not provide a default size.
+   */
+  private float fontSize;
+
+  /**
+   * Constructor that uses the provided default size of 12pt as font size.
+   */
+  public UnicodeSlickRenderFontLoader() {
+    this(DEFAULT_SIZE);
+  }
+
+  /**
+   * This constructor allows setting the size all fonts are load with.
+   *
+   * @param defaultSize the new size of the font
+   */
+  public UnicodeSlickRenderFontLoader(final float defaultSize) {
+    fontSize = defaultSize;
+  }
 
   /**
    * Load the font. The name of the font will be used as name of the Hiero settings file. The true type font file will
@@ -35,9 +55,7 @@ public final class UnicodeSlickRenderFontLoader extends AbstractJavaSlickRenderF
       throw new SlickLoadFontException("Loading TTF Font failed.");
     }
 
-    if (javaFont.getSize() == 1) {
-      javaFont = javaFont.deriveFont(DEFAULT_SIZE);
-    }
+    javaFont = javaFont.deriveFont(fontSize);
 
     try {
       final UnicodeFont uniFont = new UnicodeFont(javaFont);

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/font/loader/UnicodeSlickRenderFontLoader.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/font/loader/UnicodeSlickRenderFontLoader.java
@@ -17,7 +17,8 @@ import org.newdawn.slick.font.effects.ColorEffect;
 public final class UnicodeSlickRenderFontLoader extends AbstractJavaSlickRenderFontLoader {
   /**
    * The default size of a font. This value is needed as TrueType fonts in general do not have a default size,
-   * but Nifty expects a font to be rendered at default size.
+   * but Nifty
+   * expects a font to be rendered at default size.
    */
   private static final float DEFAULT_SIZE = 12.0f;
 

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/image/ImageSlickRenderImage.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/image/ImageSlickRenderImage.java
@@ -1,16 +1,14 @@
 package de.lessvoid.nifty.slick2d.render.image;
 
+import de.lessvoid.nifty.slick2d.render.SlickRenderUtils;
+import de.lessvoid.nifty.tools.Color;
 import org.newdawn.slick.Graphics;
 import org.newdawn.slick.Image;
 import org.newdawn.slick.SlickException;
 
-import de.lessvoid.nifty.slick2d.render.SlickRenderUtils;
-import de.lessvoid.nifty.tools.Color;
-
 /**
- * This slick render image implementation uses a Slick image to draw on the
- * screen.
- * 
+ * This slick render image implementation uses a Slick image to draw on the screen.
+ *
  * @author Martin Karing &lt;nitram@illarion.org&gt;
  */
 public class ImageSlickRenderImage implements SlickRenderImage {
@@ -20,33 +18,30 @@ public class ImageSlickRenderImage implements SlickRenderImage {
   private final Image image;
 
   /**
-   * This instance of a slick color is used to avoid the need to create a new
-   * color instance every time this image is rendered.
+   * This instance of a slick color is used to avoid the need to create a new color instance every time this image is
+   * rendered.
    */
   private final org.newdawn.slick.Color slickColor;
 
   /**
-   * Create this render image that is supposed to render a specified Slick
-   * image.
-   * 
-   * @param image
-   *          the image to draw
+   * Create this render image that is supposed to render a specified Slick image.
+   *
+   * @param usedImage the image to draw
    */
-  public ImageSlickRenderImage(final Image image) {
-    this.image = image;
-    slickColor = new org.newdawn.slick.Color(0.f, 0.f, 0.f, 0.f);
+  public ImageSlickRenderImage(final Image usedImage) {
+    image = usedImage;
+    slickColor = new org.newdawn.slick.Color(0.0f, 0.0f, 0.0f, 0.0f);
   }
 
   /**
-   * Dispose this image. After calling this method its not possible anymore to
-   * render this image. Also all functions of this image are likely to yield
-   * invalid results.
+   * Dispose this image. After calling this method its not possible anymore to render this image. Also all functions of
+   * this image are likely to yield invalid results.
    */
   @Override
   public void dispose() {
     try {
       getImage().destroy();
-    } catch (final SlickException e) {
+    } catch (final SlickException ignored) {
       // Destroying failed... does not matter
     }
   }
@@ -60,11 +55,10 @@ public class ImageSlickRenderImage implements SlickRenderImage {
   }
 
   /**
-   * Get the image that is drawn by this render image. When overwriting this
-   * class its possible to alter this function in order to receive the image in
-   * different ways. The default implementation uses the image stored in this
+   * Get the image that is drawn by this render image. When overwriting this class its possible to alter this function
+   * in order to receive the image in different ways. The default implementation uses the image stored in this
    * instance.
-   * 
+   *
    * @return the used image
    */
   protected Image getImage() {
@@ -79,9 +73,6 @@ public class ImageSlickRenderImage implements SlickRenderImage {
     return getImage().getWidth();
   }
 
-  /**
-   * {@inheritDoc}
-   */
   @Override
   public void renderImage(
       final Graphics g,
@@ -98,9 +89,6 @@ public class ImageSlickRenderImage implements SlickRenderImage {
     renderImage(g, x, y, width, height, 0, 0, getWidth(), getHeight(), color, scale, centerX, centerY);
   }
 
-  /**
-   * {@inheritDoc}
-   */
   @Override
   public void renderImage(
       final Graphics g,

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/image/ImageSlickRenderImage.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/image/ImageSlickRenderImage.java
@@ -47,7 +47,7 @@ public class ImageSlickRenderImage implements SlickRenderImage {
     try {
       getImage().destroy();
     } catch (final SlickException e) {
-      // Destorying failed... does not matter
+      // Destroying failed... does not matter
     }
   }
 

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/image/SlickLoadImageException.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/image/SlickLoadImageException.java
@@ -3,9 +3,8 @@ package de.lessvoid.nifty.slick2d.render.image;
 import de.lessvoid.nifty.slick2d.loaders.SlickLoadException;
 
 /**
- * This exception is expected to be thrown be the constructor of this class in
- * case loading the specified image failed.
- * 
+ * This exception is expected to be thrown be the constructor of this class in case loading the specified image failed.
+ *
  * @author Martin Karing &lt;nitram@illarion.org&gt;
  */
 public final class SlickLoadImageException extends SlickLoadException {
@@ -18,7 +17,6 @@ public final class SlickLoadImageException extends SlickLoadException {
    * Create the exception without an attached message or parent Throwable.
    */
   public SlickLoadImageException() {
-    super();
   }
 
   /**

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/image/SlickLoadImageException.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/image/SlickLoadImageException.java
@@ -19,26 +19,33 @@ public final class SlickLoadImageException extends SlickLoadException {
    */
   public SlickLoadImageException() {
     super();
-  };
+  }
 
   /**
    * Create the exception with an attached message and without parent Throwable.
+   *
+   * @param msg The message that is attached to this exception
    */
   public SlickLoadImageException(final String msg) {
     super(msg);
-  };
+  }
 
   /**
    * Create the exception with an attached message and parent Throwable.
+   *
+   * @param msg The message that is attached to this exception
+   * @param e The throwable that caused this exception
    */
   public SlickLoadImageException(final String msg, final Throwable e) {
     super(msg, e);
-  };
+  }
 
   /**
    * Create the exception without an attached message and with parent Throwable.
+   *
+   * @param e The throwable that caused this exception
    */
   public SlickLoadImageException(final Throwable e) {
     super(e);
-  };
+  }
 }

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/image/SlickRenderImage.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/image/SlickRenderImage.java
@@ -1,67 +1,45 @@
 package de.lessvoid.nifty.slick2d.render.image;
 
-import org.newdawn.slick.Graphics;
-
 import de.lessvoid.nifty.spi.render.RenderImage;
 import de.lessvoid.nifty.tools.Color;
+import org.newdawn.slick.Graphics;
 
 /**
- * This slick render image extends the normal render image in order to allow the
- * render device to draw this images easily.
- * 
+ * This slick render image extends the normal render image in order to allow the render device to draw this images
+ * easily.
+ *
  * @author Martin Karing &lt;nitram@illarion.org&gt;
  */
 public interface SlickRenderImage extends RenderImage {
   /**
    * Draw the entire image on the screen.
-   * 
-   * @param g
-   *          the graphics instance that is used for rendering
-   * @param x
-   *          the x coordinate of the image on the screen
-   * @param y
-   *          the y coordinate of the image on the screen
-   * @param width
-   *          the width of the image on the screen
-   * @param height
-   *          the height of the image on the screen
-   * @param color
-   *          the color that is applied to the image
-   * @param scale
-   *          scaling factor that is applied to the image, the image is scaled
-   *          around the center of the image
+   *
+   * @param g the graphics instance that is used for rendering
+   * @param x the x coordinate of the image on the screen
+   * @param y the y coordinate of the image on the screen
+   * @param width the width of the image on the screen
+   * @param height the height of the image on the screen
+   * @param color the color that is applied to the image
+   * @param scale scaling factor that is applied to the image, the image is scaled around the center of the image
    */
   void renderImage(Graphics g, int x, int y, int width, int height, Color color, float scale);
 
   /**
    * Draw a part of a image on the screen.
-   * 
-   * @param g
-   *          the graphics instance that is used for rendering
-   * @param x
-   *          the x coordinate on the screen to draw the image to
-   * @param y
-   *          the y coordinate on the screen to draw the image to
-   * @param w
-   *          the width of the image on the screen
-   * @param h
-   *          the height of the image on the screen
-   * @param srcX
-   *          the x coordinate on the image
-   * @param srcY
-   *          the y coordinate on the image
-   * @param srcW
-   *          the width of the sub-image that is supposed to be drawn
-   * @param srcH
-   *          the height of the sub-image that is supposed to be drawn
-   * @param color
-   *          the color that is supposed to be applied to the image
-   * @param scale
-   *          the scaling factor that should be applied to the image
-   * @param centerX
-   *          the x coordinate on the screen the image is scaled around
-   * @param centerY
-   *          the y coordinate on the screen the image is scaled around
+   *
+   * @param g the graphics instance that is used for rendering
+   * @param x the x coordinate on the screen to draw the image to
+   * @param y the y coordinate on the screen to draw the image to
+   * @param w the width of the image on the screen
+   * @param h the height of the image on the screen
+   * @param srcX the x coordinate on the image
+   * @param srcY the y coordinate on the image
+   * @param srcW the width of the sub-image that is supposed to be drawn
+   * @param srcH the height of the sub-image that is supposed to be drawn
+   * @param color the color that is supposed to be applied to the image
+   * @param scale the scaling factor that should be applied to the image
+   * @param centerX the x coordinate on the screen the image is scaled around
+   * @param centerY the y coordinate on the screen the image is scaled around
    */
   void renderImage(
       Graphics g,

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/image/loader/ImageSlickRenderImageLoader.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/image/loader/ImageSlickRenderImageLoader.java
@@ -1,14 +1,14 @@
 package de.lessvoid.nifty.slick2d.render.image.loader;
 
-import org.newdawn.slick.Image;
-
 import de.lessvoid.nifty.slick2d.render.image.ImageSlickRenderImage;
 import de.lessvoid.nifty.slick2d.render.image.SlickLoadImageException;
 import de.lessvoid.nifty.slick2d.render.image.SlickRenderImage;
+import org.newdawn.slick.Image;
+import org.newdawn.slick.SlickException;
 
 /**
  * This image loader takes care for loading Slick image based RenderImages.
- * 
+ *
  * @author Martin Karing &lt;nitram@illarion.org&gt;
  */
 public final class ImageSlickRenderImageLoader implements SlickRenderImageLoader {
@@ -18,14 +18,10 @@ public final class ImageSlickRenderImageLoader implements SlickRenderImageLoader
   @Override
   public SlickRenderImage loadImage(final String filename, final boolean filterLinear) throws SlickLoadImageException {
     try {
-      Image image;
-      if (filterLinear) {
-        image = new Image(filename, false, Image.FILTER_LINEAR);
-      } else {
-        image = new Image(filename, false, Image.FILTER_NEAREST);
-      }
+      final int filter = filterLinear ? Image.FILTER_LINEAR : Image.FILTER_NEAREST;
+      final Image image = new Image(filename, false, filter);
       return new ImageSlickRenderImage(image);
-    } catch (final Exception e) {
+    } catch (final SlickException e) {
       throw new SlickLoadImageException("Loading the image \"" + filename + "\" failed.", e);
     }
   }

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/image/loader/ImageSlickRenderImageLoader.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/image/loader/ImageSlickRenderImageLoader.java
@@ -18,7 +18,7 @@ public final class ImageSlickRenderImageLoader implements SlickRenderImageLoader
   @Override
   public SlickRenderImage loadImage(final String filename, final boolean filterLinear) throws SlickLoadImageException {
     try {
-      Image image = null;
+      Image image;
       if (filterLinear) {
         image = new Image(filename, false, Image.FILTER_LINEAR);
       } else {

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/image/loader/SlickRenderImageLoader.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/image/loader/SlickRenderImageLoader.java
@@ -6,21 +6,17 @@ import de.lessvoid.nifty.slick2d.render.image.SlickRenderImage;
 
 /**
  * This interface defines a image loader that loads a image to be used by Nifty.
- * 
+ *
  * @author Martin Karing &lt;nitram@illarion.org&gt;
  */
 public interface SlickRenderImageLoader extends SlickLoader {
   /**
    * Load a image that is defined by the filename.
-   * 
-   * @param filename
-   *          the name of the file to load
-   * @param filterLinear
-   *          <code>true</code> in case the image is supposed to be filtered
-   *          linear
+   *
+   * @param filename the name of the file to load
+   * @param filterLinear {@code true} in case the image is supposed to be filtered linear
    * @return the loaded image
-   * @throws SlickLoadImageException
-   *           in case loading the image fails
+   * @throws SlickLoadImageException in case loading the image fails
    */
   SlickRenderImage loadImage(String filename, boolean filterLinear) throws SlickLoadImageException;
 }

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/sound/SlickSoundDevice.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/sound/SlickSoundDevice.java
@@ -9,17 +9,15 @@ import de.lessvoid.nifty.tools.resourceloader.NiftyResourceLoader;
 
 /**
  * Slick Implementation of the SoundLoader.
- * 
+ *
  * @author Martin Karing &lt;nitram@illarion.org&gt;
  */
 public final class SlickSoundDevice implements SoundDevice {
   /**
    * Load a music piece.
-   * 
-   * @param soundSystem
-   *          soundSystem
-   * @param filename
-   *          file to load
+   *
+   * @param soundSystem soundSystem
+   * @param filename file to load
    * @return the music piece
    */
   @Override
@@ -29,11 +27,9 @@ public final class SlickSoundDevice implements SoundDevice {
 
   /**
    * Load a sound.
-   * 
-   * @param soundSystem
-   *          soundSystem
-   * @param filename
-   *          filename of sound
+   *
+   * @param soundSystem soundSystem
+   * @param filename filename of sound
    * @return handle to sound
    */
   @Override

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/sound/music/MusicSlickMusicHandle.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/sound/music/MusicSlickMusicHandle.java
@@ -1,13 +1,11 @@
 package de.lessvoid.nifty.slick2d.sound.music;
 
+import de.lessvoid.nifty.sound.SoundSystem;
 import org.newdawn.slick.Music;
 
-import de.lessvoid.nifty.sound.SoundSystem;
-
 /**
- * This Slick music handle uses the slick music class to implement and playback
- * music.
- * 
+ * This Slick music handle uses the slick music class to implement and playback music.
+ *
  * @author Martin Karing &lt;nitram@illarion.org&gt;
  */
 public class MusicSlickMusicHandle implements SlickMusicHandle {
@@ -23,14 +21,12 @@ public class MusicSlickMusicHandle implements SlickMusicHandle {
 
   /**
    * Create a new music handle that wraps a Slick music object.
-   * 
-   * @param soundSystem
-   *          the sound system that manages this music
-   * @param music
-   *          the music object that is used for playback
+   *
+   * @param soundSystem the sound system that manages this music
+   * @param backgroundMusic the music object that is used for playback
    */
-  public MusicSlickMusicHandle(final SoundSystem soundSystem, final Music music) {
-    this.music = music;
+  public MusicSlickMusicHandle(final SoundSystem soundSystem, final Music backgroundMusic) {
+    music = backgroundMusic;
     soundSys = soundSystem;
   }
 
@@ -63,7 +59,7 @@ public class MusicSlickMusicHandle implements SlickMusicHandle {
    */
   @Override
   public void play() {
-    music.play(1.f, soundSys.getMusicVolume());
+    music.play(1.0f, soundSys.getMusicVolume());
   }
 
   /**

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/sound/music/SlickLoadMusicException.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/sound/music/SlickLoadMusicException.java
@@ -19,26 +19,33 @@ public final class SlickLoadMusicException extends SlickLoadException {
    */
   public SlickLoadMusicException() {
     super();
-  };
+  }
 
   /**
    * Create the exception with an attached message and without parent Throwable.
+   *
+   * @param msg The message that is attached to this exception
    */
   public SlickLoadMusicException(final String msg) {
     super(msg);
-  };
+  }
 
   /**
    * Create the exception with an attached message and parent Throwable.
+   *
+   * @param msg The message that is attached to this exception
+   * @param e The throwable that caused this exception
    */
   public SlickLoadMusicException(final String msg, final Throwable e) {
     super(msg, e);
-  };
+  }
 
   /**
    * Create the exception without an attached message and with parent Throwable.
+   *
+   * @param e The throwable that caused this exception
    */
   public SlickLoadMusicException(final Throwable e) {
     super(e);
-  };
+  }
 }

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/sound/music/SlickLoadMusicException.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/sound/music/SlickLoadMusicException.java
@@ -3,9 +3,8 @@ package de.lessvoid.nifty.slick2d.sound.music;
 import de.lessvoid.nifty.slick2d.loaders.SlickLoadException;
 
 /**
- * This exception is expected to be thrown be the constructor of this class in
- * case loading the specified music failed.
- * 
+ * This exception is expected to be thrown be the constructor of this class in case loading the specified music failed.
+ *
  * @author Martin Karing &lt;nitram@illarion.org&gt;
  */
 public final class SlickLoadMusicException extends SlickLoadException {
@@ -18,7 +17,6 @@ public final class SlickLoadMusicException extends SlickLoadException {
    * Create the exception without an attached message or parent Throwable.
    */
   public SlickLoadMusicException() {
-    super();
   }
 
   /**

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/sound/music/SlickMusicHandle.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/sound/music/SlickMusicHandle.java
@@ -4,7 +4,7 @@ import de.lessvoid.nifty.spi.sound.SoundHandle;
 
 /**
  * This is the interface for all Slick music handles.
- * 
+ *
  * @author Martin Karing &lt;nitram@illarion.org&gt;
  */
 public interface SlickMusicHandle extends SoundHandle {

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/sound/music/loader/MusicSlickMusicLoader.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/sound/music/loader/MusicSlickMusicLoader.java
@@ -1,16 +1,15 @@
 package de.lessvoid.nifty.slick2d.sound.music.loader;
 
-import org.newdawn.slick.Music;
-import org.newdawn.slick.SlickException;
-
 import de.lessvoid.nifty.slick2d.sound.music.MusicSlickMusicHandle;
 import de.lessvoid.nifty.slick2d.sound.music.SlickLoadMusicException;
 import de.lessvoid.nifty.slick2d.sound.music.SlickMusicHandle;
 import de.lessvoid.nifty.sound.SoundSystem;
+import org.newdawn.slick.Music;
+import org.newdawn.slick.SlickException;
 
 /**
  * The Slick music loader that uses Slick music objects for playing the music.
- * 
+ *
  * @author Martin Karing &lt;nitram@illarion.org&gt;
  */
 public final class MusicSlickMusicLoader implements SlickMusicLoader {
@@ -18,8 +17,8 @@ public final class MusicSlickMusicLoader implements SlickMusicLoader {
    * Load the music.
    */
   @Override
-  public SlickMusicHandle loadMusic(final SoundSystem soundSystem, final String filename)
-      throws SlickLoadMusicException {
+  public SlickMusicHandle loadMusic(
+      final SoundSystem soundSystem, final String filename) throws SlickLoadMusicException {
 
     try {
       return new MusicSlickMusicHandle(soundSystem, new Music(filename, true));

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/sound/music/loader/SlickMusicLoader.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/sound/music/loader/SlickMusicLoader.java
@@ -15,7 +15,7 @@ public interface SlickMusicLoader extends SlickLoader {
    * Load some music.
    * 
    * @param soundSystem
-   *          the Nifty soundsystem that is going to manage the load music
+   *          the Nifty sound system that is going to manage the load music
    * @param filename
    *          the name of the file that stores the music
    * @return the loaded music

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/sound/music/loader/SlickMusicLoader.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/sound/music/loader/SlickMusicLoader.java
@@ -7,20 +7,17 @@ import de.lessvoid.nifty.sound.SoundSystem;
 
 /**
  * The interface for all music loaders.
- * 
+ *
  * @author Martin Karing &lt;nitram@illarion.org&gt;
  */
 public interface SlickMusicLoader extends SlickLoader {
   /**
    * Load some music.
-   * 
-   * @param soundSystem
-   *          the Nifty sound system that is going to manage the load music
-   * @param filename
-   *          the name of the file that stores the music
+   *
+   * @param soundSystem the Nifty sound system that is going to manage the load music
+   * @param filename the name of the file that stores the music
    * @return the loaded music
-   * @throws SlickLoadMusicException
-   *           in case loading the music failed
+   * @throws SlickLoadMusicException in case loading the music failed
    */
-  SlickMusicHandle loadMusic(SoundSystem soundSystem, final String filename) throws SlickLoadMusicException;
+  SlickMusicHandle loadMusic(SoundSystem soundSystem, String filename) throws SlickLoadMusicException;
 }

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/sound/sound/SlickLoadSoundException.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/sound/sound/SlickLoadSoundException.java
@@ -3,9 +3,8 @@ package de.lessvoid.nifty.slick2d.sound.sound;
 import de.lessvoid.nifty.slick2d.loaders.SlickLoadException;
 
 /**
- * This exception is expected to be thrown be the constructor of this class in
- * case loading the specified sound failed.
- * 
+ * This exception is expected to be thrown be the constructor of this class in case loading the specified sound failed.
+ *
  * @author Martin Karing &lt;nitram@illarion.org&gt;
  */
 public final class SlickLoadSoundException extends SlickLoadException {
@@ -18,7 +17,6 @@ public final class SlickLoadSoundException extends SlickLoadException {
    * Create the exception without an attached message or parent Throwable.
    */
   public SlickLoadSoundException() {
-    super();
   }
 
   /**

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/sound/sound/SlickLoadSoundException.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/sound/sound/SlickLoadSoundException.java
@@ -19,26 +19,33 @@ public final class SlickLoadSoundException extends SlickLoadException {
    */
   public SlickLoadSoundException() {
     super();
-  };
+  }
 
   /**
    * Create the exception with an attached message and without parent Throwable.
+   *
+   * @param msg The message that is attached to this exception
    */
   public SlickLoadSoundException(final String msg) {
     super(msg);
-  };
+  }
 
   /**
    * Create the exception with an attached message and parent Throwable.
+   *
+   * @param msg The message that is attached to this exception
+   * @param e The throwable that caused this exception
    */
   public SlickLoadSoundException(final String msg, final Throwable e) {
     super(msg, e);
-  };
+  }
 
   /**
    * Create the exception without an attached message and with parent Throwable.
+   *
+   * @param e The throwable that caused this exception
    */
   public SlickLoadSoundException(final Throwable e) {
     super(e);
-  };
+  }
 }

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/sound/sound/SoundSlickSoundHandle.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/sound/sound/SoundSlickSoundHandle.java
@@ -1,13 +1,11 @@
 package de.lessvoid.nifty.slick2d.sound.sound;
 
+import de.lessvoid.nifty.sound.SoundSystem;
 import org.newdawn.slick.Sound;
 
-import de.lessvoid.nifty.sound.SoundSystem;
-
 /**
- * This Slick music handle uses the slick music class to implement and playback
- * music.
- * 
+ * This Slick music handle uses the slick music class to implement and playback music.
+ *
  * @author Martin Karing &lt;nitram@illarion.org&gt;
  */
 public class SoundSlickSoundHandle implements SlickSoundHandle {
@@ -23,14 +21,12 @@ public class SoundSlickSoundHandle implements SlickSoundHandle {
 
   /**
    * Create a new sound handle that wraps a Slick Sound object.
-   * 
-   * @param soundSystem
-   *          the sound system that manages this sound
-   * @param sound
-   *          the sound object that is used for playback
+   *
+   * @param soundSystem the sound system that manages this sound
+   * @param soundEffect the sound object that is used for playback
    */
-  public SoundSlickSoundHandle(final SoundSystem soundSystem, final Sound sound) {
-    this.sound = sound;
+  public SoundSlickSoundHandle(final SoundSystem soundSystem, final Sound soundEffect) {
+    sound = soundEffect;
     soundSys = soundSystem;
   }
 
@@ -63,12 +59,11 @@ public class SoundSlickSoundHandle implements SlickSoundHandle {
    */
   @Override
   public void play() {
-    sound.play(1.f, soundSys.getSoundVolume());
+    sound.play(1.0f, soundSys.getSoundVolume());
   }
 
   /**
-   * Change the sound volume. This how ever is not supported by the Slick
-   * sounds.
+   * Change the sound volume. This how ever is not supported by the Slick sounds.
    */
   @Override
   public void setVolume(final float volume) {

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/sound/sound/loader/SlickSoundLoader.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/sound/sound/loader/SlickSoundLoader.java
@@ -7,20 +7,17 @@ import de.lessvoid.nifty.sound.SoundSystem;
 
 /**
  * The interface for all loaders that take care for loading sounds.
- * 
+ *
  * @author Martin Karing &lt;nitram@illarion.org&gt;
  */
 public interface SlickSoundLoader extends SlickLoader {
   /**
    * Load a new sound.
-   * 
-   * @param soundSystem
-   *          the sound system that manages the sound
-   * @param filename
-   *          the name of the file storing the sound data
+   *
+   * @param soundSystem the sound system that manages the sound
+   * @param filename the name of the file storing the sound data
    * @return the loaded sound
-   * @throws SlickLoadSoundException
-   *           in case loading the sound fails
+   * @throws SlickLoadSoundException in case loading the sound fails
    */
   SlickSoundHandle loadSound(SoundSystem soundSystem, String filename) throws SlickLoadSoundException;
 }

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/sound/sound/loader/SoundSlickSoundLoader.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/sound/sound/loader/SoundSlickSoundLoader.java
@@ -1,16 +1,15 @@
 package de.lessvoid.nifty.slick2d.sound.sound.loader;
 
-import org.newdawn.slick.SlickException;
-import org.newdawn.slick.Sound;
-
 import de.lessvoid.nifty.slick2d.sound.sound.SlickLoadSoundException;
 import de.lessvoid.nifty.slick2d.sound.sound.SlickSoundHandle;
 import de.lessvoid.nifty.slick2d.sound.sound.SoundSlickSoundHandle;
 import de.lessvoid.nifty.sound.SoundSystem;
+import org.newdawn.slick.SlickException;
+import org.newdawn.slick.Sound;
 
 /**
  * Load a Slick sound handle that wraps a slick sound.
- * 
+ *
  * @author Martin Karing &lt;nitram@illarion.org&gt;
  */
 public final class SoundSlickSoundLoader implements SlickSoundLoader {
@@ -18,8 +17,8 @@ public final class SoundSlickSoundLoader implements SlickSoundLoader {
    * Load the sound.
    */
   @Override
-  public SlickSoundHandle loadSound(final SoundSystem soundSystem, final String filename)
-      throws SlickLoadSoundException {
+  public SlickSoundHandle loadSound(
+      final SoundSystem soundSystem, final String filename) throws SlickLoadSoundException {
     try {
       return new SoundSlickSoundHandle(soundSystem, new Sound(filename));
     } catch (final SlickException e) {

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/time/LWJGLTimeProvider.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/time/LWJGLTimeProvider.java
@@ -6,19 +6,15 @@ import de.lessvoid.nifty.spi.time.TimeProvider;
 
 /**
  * This time provider uses the timer that is provided by LWJGL.
- * 
+ *
  * @author Martin Karing &lt;nitram@illarion.org&gt;
  */
 public class LWJGLTimeProvider implements TimeProvider {
   /**
-   * The conversation factor from the time provided by the LWJGL time to the
-   * time expected by Nifty.
+   * The conversation factor from the time provided by the LWJGL time to the time expected by Nifty.
    */
   private static final long CONVERSATION_FACTOR = 1000;
-  
-  /**
-   * {@inheritDoc}
-   */
+
   @Override
   public long getMsTime() {
     return (Sys.getTime() * CONVERSATION_FACTOR) / Sys.getTimerResolution();


### PR DESCRIPTION
Zwei neue Features im Slick-Renderer.

Einmal exklusives Sperren der Eingaben (Alle Events werden ans Spiel geleitet)
Und zum anderen die Möglichkeit die renderreihenfolge Nifty-Spiel zu ändern.
