### PR TITLE
Bugfix: nifty.resolutionChanged() not working using JoglRenderDevice

### DIFF
--- a/nifty-renderer-jogl2/src/main/java/de/lessvoid/nifty/renderer/jogl/render/JoglRenderDevice.java
+++ b/nifty-renderer-jogl2/src/main/java/de/lessvoid/nifty/renderer/jogl/render/JoglRenderDevice.java
@@ -112,7 +112,7 @@ public class JoglRenderDevice implements RenderDevice {
         }
         return viewportHeight;
     }
-
+    
     private void getViewport() {
         final GL gl = GLContext.getCurrentGL();
         gl.glGetIntegerv(GL.GL_VIEWPORT, viewportBuffer);
@@ -120,7 +120,13 @@ public class JoglRenderDevice implements RenderDevice {
         viewportHeight = viewportBuffer.get(3);
         log.info("Viewport: " + viewportWidth + ", " + viewportHeight);
     }
-
+    /**
+     * Clears cached Veiwport dimensions.
+     * Call this method if your window has been resized.
+     */
+    public void invalidateViewport(){
+        viewportHeight = viewportWidth = 0;
+    }
     public void beginFrame() {
         log.fine("beginFrame()");
 


### PR DESCRIPTION
The `JoglRenderDevice` only reads the viewport dimensions once, so calling the `resolutionChanged()` method on nifty when your viewport has changed does not reposition your elements correctly.

I solved this by adding a public `invalidateViewport()` method to `JoglRenderDevice` that clears cached values; 

Simply call `invalidateViewport()` before calling `resolutionChanged()` and everything works as expected

The only downside is that it's just another "gotcha" a JOGL user will have to face when he's introduced to nifty.
Maybe this could be implemented using the eventbus instead if resolutionChanged() generates an event.

Or to let  `JoglRenderDevice` implement `GLEventListener` and automatically clear values on `reshape` event.
That would also let us handle the `dispose` event, but i'm not sure that works with nifty at all cause the RenderImage interface does not support texture-recreation. 
I've had to handle `dispose` events in my earlier builds on Win64 but in the end i resolved to completely recreate the nifty instance when that happens.
