### PR TITLE
Feature: Element.getDescendants()

### DIFF
--- a/nifty-core/src/main/java/de/lessvoid/nifty/elements/Element.java
+++ b/nifty-core/src/main/java/de/lessvoid/nifty/elements/Element.java
@@ -28,6 +28,7 @@ import de.lessvoid.nifty.elements.render.ElementRenderer;
 import de.lessvoid.nifty.elements.render.ImageRenderer;
 import de.lessvoid.nifty.elements.render.PanelRenderer;
 import de.lessvoid.nifty.elements.render.TextRenderer;
+import de.lessvoid.nifty.elements.tools.ElementTreeTraverser;
 import de.lessvoid.nifty.input.NiftyMouseInputEvent;
 import de.lessvoid.nifty.input.keyboard.KeyboardInputEvent;
 import de.lessvoid.nifty.layout.LayoutPart;
@@ -50,6 +51,7 @@ import de.lessvoid.nifty.spi.time.TimeProvider;
 import de.lessvoid.nifty.tools.NullObjectFactory;
 import de.lessvoid.nifty.tools.SizeValue;
 import de.lessvoid.xml.xpp3.Attributes;
+import java.util.*;
 
 /**
  * The Element.
@@ -122,7 +124,7 @@ public class Element implements NiftyEvent<Void>, EffectManager.Notify {
    * The focus handler this element is attached to.
    */
   private FocusHandler focusHandler;
-  
+
   /**
    * enable element.
    */
@@ -133,7 +135,7 @@ public class Element implements NiftyEvent<Void>, EffectManager.Notify {
    * to start the onEnabled/onDisabled effects when the element is already enabled/disabled.
    */
   private int enabledCount;
-  
+
   /**
    * visible element.
    */
@@ -283,7 +285,7 @@ public class Element implements NiftyEvent<Void>, EffectManager.Notify {
   }
 
   /**
-   * This is used when the element is being created from an ElementType in the loading process. 
+   * This is used when the element is being created from an ElementType in the loading process.
    */
   public void initializeFromAttributes(final Attributes attributes, final NiftyRenderEngine renderEngine) {
     layoutPart.getBoxConstraints().setHeight(convert.sizeValue(attributes.get("height")));
@@ -423,7 +425,7 @@ public class Element implements NiftyEvent<Void>, EffectManager.Notify {
   /**
    * get element state as string.
    * @param offset offset string
-   * @param regex 
+   * @param regex
    * @return the element state as string.
    */
   public String getElementStateString(final String offset) {
@@ -502,7 +504,7 @@ public class Element implements NiftyEvent<Void>, EffectManager.Notify {
     if (interactionBlocked) {
       return "interactionBlocked";
     }
-    
+
     if (!enabled) {
       return "disabled";
     }
@@ -553,7 +555,7 @@ public class Element implements NiftyEvent<Void>, EffectManager.Notify {
   public int getWidth() {
     return layoutPart.getBox().getWidth();
   }
-  
+
   /**
    * Sets the height of this element
    * @param height the new height in pixels
@@ -561,7 +563,7 @@ public class Element implements NiftyEvent<Void>, EffectManager.Notify {
   public void setHeight(int height) {
     layoutPart.getBox().setHeight(height);
   }
-  
+
   /**
    * Sets the width of this element
    * @param width the new width in pixels
@@ -578,6 +580,13 @@ public class Element implements NiftyEvent<Void>, EffectManager.Notify {
     return elements;
   }
 
+  /**
+   * get all children and all childrens' children.
+   * @return an iterator that will traverse the entire Element tree.
+   */
+  public Iterator<Element> getDescendants(){
+    return new ElementTreeTraverser(this);
+  }
   /**
    * add a child element.
    * @param widget the child to add
@@ -842,7 +851,7 @@ public class Element implements NiftyEvent<Void>, EffectManager.Notify {
       w.resetSingleEffect(effectEventId);
     }
   }
-  
+
   public void resetSingleEffect(final EffectEventId effectEventId, final String customKey) {
     effectManager.resetSingleEffect(effectEventId, customKey);
     for (int i=0; i<elements.size(); i++) {
@@ -901,7 +910,7 @@ public class Element implements NiftyEvent<Void>, EffectManager.Notify {
 
   public SizeValue getConstraintY() {
     return layoutPart.getBoxConstraints().getY();
-  } 
+  }
 
   /**
    * get current width constraint.
@@ -1936,10 +1945,10 @@ public class Element implements NiftyEvent<Void>, EffectManager.Notify {
   public boolean isFocusable() {
     return focusable && enabled && visible && hasVisibleParent();
   }
-  
+
   private boolean hasVisibleParent() {
     if (parent != null) {
-      return parent.visible && parent.hasVisibleParent(); 
+      return parent.visible && parent.hasVisibleParent();
     }
     return true;
   }
@@ -2018,7 +2027,7 @@ public class Element implements NiftyEvent<Void>, EffectManager.Notify {
       element.reactivate();
     }
   }
-  
+
   private void notifyListeners() {
     nifty.publishEvent(id, this);
   }

--- a/nifty-core/src/main/java/de/lessvoid/nifty/elements/tools/ElementTreeTraverser.java
+++ b/nifty-core/src/main/java/de/lessvoid/nifty/elements/tools/ElementTreeTraverser.java
@@ -1,0 +1,48 @@
+/*
+ * To change this template, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package de.lessvoid.nifty.elements.tools;
+
+import de.lessvoid.nifty.elements.Element;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+/**
+ *
+ * @author telamon
+ */
+public class ElementTreeTraverser implements Iterator<Element>{
+    private ArrayList<Iterator<Element>> iterators =  new ArrayList<Iterator<Element>>();
+    private Iterator<Element> current;
+    public ElementTreeTraverser(Element e){
+        current = e.getElements().listIterator();
+    }
+
+    @Override
+    public boolean hasNext() {
+        return current.hasNext() || !iterators.isEmpty();
+    }
+
+    @Override
+    public Element next() {
+        if(current.hasNext()){
+            Element e = current.next();
+            if(!e.getElements().isEmpty())
+                iterators.add(e.getElements().listIterator());
+
+            return e;
+        }else if(!iterators.isEmpty()){
+            current = iterators.remove(0);
+            return next();
+        }
+        throw new NoSuchElementException();
+    }
+
+    @Override
+    public void remove() {
+        throw new UnsupportedOperationException();
+    }
+
+}


### PR DESCRIPTION
Function added to Element.java:

```
 /**
 * get all children and all childrens' children.    
 * @return an iterator that will traverse the entire Element tree.
 */
 public Iterator<Element> getDescendants()
```

I've worked with many other node-tree'ish implementations and realized that getting a List or Iterator of all descendants of a node was missing in nifty.
I hope I haven't missed an existing interface somewhere that already accomplishes this.

I've created a simple tree traverser using the `Iterator` interface in order to avoid pre-generating lists of elements and waste resources.

The iterator implementation is called `ElementTreeTraverser` and I've put it in `de.lessvoid.nifty.elements.tools` package.

Feel free to accept this request if you think the feature is 'nifty' enough :)
Cheers!
