### PR TITLE
Event issue1 - 

### DIFF
--- a/nifty-core/src/main/java/de/lessvoid/nifty/elements/Element.java
+++ b/nifty-core/src/main/java/de/lessvoid/nifty/elements/Element.java
@@ -1340,7 +1340,7 @@ public class Element implements NiftyEvent<Void>, EffectManager.Notify {
    * Checks if this element can handle mouse events.
    * @return true can handle mouse events, false can't handle them
    */
-  boolean canHandleMouseEvents() {
+  public boolean canHandleMouseEvents() {
     if (isEffectActive(EffectEventId.onStartScreen)) {
       return false;
     }


### PR DESCRIPTION
Hi!

I've taken the liberty to expose  `Element#canHandleMouseEvents()` as public, I'm not sure if it's a good idea
and i'd love some feedback on this move. 

Here's the story behind that decision:

I found a bug in my software yesterday, it was related to nifty-popup layers that remain after you've called `nifty.closePopup('id');` , At first i thought it was a bug, but then I noticed that they get marked as `done = true`.

The problem in question is my mouse event handling filter;
I've chosen not to rely on `Element#buildMouseOverElements()` because it adds the MouseEvents in question to the nifty event processing que, and that is not my intention.

So to avoid that, I'm manually iterating through all elements and check their bounds and confirm that they're capable of handling the mouse event before I let the InputSystem pass it on to nifty for processing.
But my problem is that i've been using `Element#isVisisbleToMouse()` method uptil now to detect if an element can handle mouse events, but that method reports `true` for an "done" popup-layer when I need a `false` in that case.

I could not see any way to reach the `done` boolean through the api, 
so as a last resort I exposed `Element#canHandleMouseEvents()` as public.
