### PR TITLE
Cleanup

### DIFF
--- a/nifty-controls/.settings/org.eclipse.jdt.core.prefs
+++ b/nifty-controls/.settings/org.eclipse.jdt.core.prefs
@@ -1,4 +1,3 @@
-#Sat Jul 17 14:59:01 CEST 2010
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
 org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.6
@@ -9,5 +8,4 @@ org.eclipse.jdt.core.compiler.debug.localVariable=generate
 org.eclipse.jdt.core.compiler.debug.sourceFile=generate
 org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
 org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
-org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
 org.eclipse.jdt.core.compiler.source=1.6

--- a/nifty-controls/src/main/java/de/lessvoid/nifty/controls/ButtonClickedEvent.java
+++ b/nifty-controls/src/main/java/de/lessvoid/nifty/controls/ButtonClickedEvent.java
@@ -2,7 +2,7 @@ package de.lessvoid.nifty.controls;
 
 import de.lessvoid.nifty.NiftyEvent;
 
-public class ButtonClickedEvent implements NiftyEvent<Void> {
+public class ButtonClickedEvent implements NiftyEvent {
   private Button button;
 
   public ButtonClickedEvent(final Button button) {

--- a/nifty-controls/src/main/java/de/lessvoid/nifty/controls/ChatTextSendEvent.java
+++ b/nifty-controls/src/main/java/de/lessvoid/nifty/controls/ChatTextSendEvent.java
@@ -11,7 +11,7 @@ import de.lessvoid.nifty.controls.chatcontrol.ChatControl;
  *
  * @author ractoc
  */
-public class ChatTextSendEvent implements NiftyEvent<Void> {
+public class ChatTextSendEvent implements NiftyEvent {
     private ChatControl chatControl;
     private String text;
 

--- a/nifty-controls/src/main/java/de/lessvoid/nifty/controls/CheckBoxStateChangedEvent.java
+++ b/nifty-controls/src/main/java/de/lessvoid/nifty/controls/CheckBoxStateChangedEvent.java
@@ -6,7 +6,6 @@ import de.lessvoid.nifty.NiftyEvent;
  * Nifty generates this event when the state of the CheckBox changes.
  * @author void
  */
-@SuppressWarnings("rawtypes")
 public class CheckBoxStateChangedEvent implements NiftyEvent {
   private CheckBox checkbox;
   private boolean checked;

--- a/nifty-controls/src/main/java/de/lessvoid/nifty/controls/ConsoleExecuteCommandEvent.java
+++ b/nifty-controls/src/main/java/de/lessvoid/nifty/controls/ConsoleExecuteCommandEvent.java
@@ -6,7 +6,6 @@ import de.lessvoid.nifty.NiftyEvent;
  * Executed when a new command is being issued on the console.
  * @author void
  */
-@SuppressWarnings("rawtypes")
 public class ConsoleExecuteCommandEvent implements NiftyEvent {
   private Console console;
   private ConsoleCommandSplitter splitter = new ConsoleCommandSplitter();

--- a/nifty-controls/src/main/java/de/lessvoid/nifty/controls/DraggableDragCanceledEvent.java
+++ b/nifty-controls/src/main/java/de/lessvoid/nifty/controls/DraggableDragCanceledEvent.java
@@ -2,7 +2,6 @@ package de.lessvoid.nifty.controls;
 
 import de.lessvoid.nifty.NiftyEvent;
 
-@SuppressWarnings("rawtypes")
 public class DraggableDragCanceledEvent implements NiftyEvent {
   private Droppable source;
   private Draggable draggable;

--- a/nifty-controls/src/main/java/de/lessvoid/nifty/controls/DraggableDragStartedEvent.java
+++ b/nifty-controls/src/main/java/de/lessvoid/nifty/controls/DraggableDragStartedEvent.java
@@ -2,7 +2,6 @@ package de.lessvoid.nifty.controls;
 
 import de.lessvoid.nifty.NiftyEvent;
 
-@SuppressWarnings("rawtypes")
 public class DraggableDragStartedEvent implements NiftyEvent {
   private Droppable source;
   private Draggable draggable;

--- a/nifty-controls/src/main/java/de/lessvoid/nifty/controls/DropDownSelectionChangedEvent.java
+++ b/nifty-controls/src/main/java/de/lessvoid/nifty/controls/DropDownSelectionChangedEvent.java
@@ -6,7 +6,7 @@ import de.lessvoid.nifty.NiftyEvent;
  * Nifty generates this event when the selection of the DropDown changes.
  * @author void
  */
-public class DropDownSelectionChangedEvent<T> implements NiftyEvent<T> {
+public class DropDownSelectionChangedEvent<T> implements NiftyEvent {
   private DropDown<T> dropDown;
   private T selection;
   private int selectionItemIndex;

--- a/nifty-controls/src/main/java/de/lessvoid/nifty/controls/DroppableDroppedEvent.java
+++ b/nifty-controls/src/main/java/de/lessvoid/nifty/controls/DroppableDroppedEvent.java
@@ -2,7 +2,6 @@ package de.lessvoid.nifty.controls;
 
 import de.lessvoid.nifty.NiftyEvent;
 
-@SuppressWarnings("rawtypes")
 public class DroppableDroppedEvent implements NiftyEvent {
   private Droppable source;
   private Draggable draggable;

--- a/nifty-controls/src/main/java/de/lessvoid/nifty/controls/ImageSelectSelectionChangedEvent.java
+++ b/nifty-controls/src/main/java/de/lessvoid/nifty/controls/ImageSelectSelectionChangedEvent.java
@@ -6,7 +6,6 @@ import de.lessvoid.nifty.NiftyEvent;
  * This event is published when the selection of the image select has been changed.
  * @author void
  */
-@SuppressWarnings("rawtypes")
 public class ImageSelectSelectionChangedEvent implements NiftyEvent {
   private ImageSelect imageSelect;
   private int selectedIndex;

--- a/nifty-controls/src/main/java/de/lessvoid/nifty/controls/ListBoxSelectionChangedEvent.java
+++ b/nifty-controls/src/main/java/de/lessvoid/nifty/controls/ListBoxSelectionChangedEvent.java
@@ -8,7 +8,7 @@ import de.lessvoid.nifty.NiftyEvent;
  * Nifty generates this event when the selection of the ListBox changes.
  * @author void
  */
-public class ListBoxSelectionChangedEvent<T> implements NiftyEvent<T> {
+public class ListBoxSelectionChangedEvent<T> implements NiftyEvent {
   private ListBox<T> listBox;
   private List<T> selection;
   private List<Integer> selectionIndices;

--- a/nifty-controls/src/main/java/de/lessvoid/nifty/controls/MenuItemActivatedEvent.java
+++ b/nifty-controls/src/main/java/de/lessvoid/nifty/controls/MenuItemActivatedEvent.java
@@ -7,7 +7,7 @@ import de.lessvoid.nifty.NiftyEvent;
  * that was activated is being transmitted in this event.
  * @author void
  */
-public class MenuItemActivatedEvent<T> implements NiftyEvent<T> {
+public class MenuItemActivatedEvent<T> implements NiftyEvent {
   private Menu<T> menu;
   private T item;
 

--- a/nifty-controls/src/main/java/de/lessvoid/nifty/controls/RadioButtonGroupStateChangedEvent.java
+++ b/nifty-controls/src/main/java/de/lessvoid/nifty/controls/RadioButtonGroupStateChangedEvent.java
@@ -7,7 +7,7 @@ import de.lessvoid.nifty.NiftyEvent;
  * collection of individual RadioButtons) has changed.
  * @author void
  */
-public class RadioButtonGroupStateChangedEvent implements NiftyEvent<Void> {
+public class RadioButtonGroupStateChangedEvent implements NiftyEvent {
   private RadioButton selectedRadioButton;
   private RadioButton previousSelectedRadioButton;
 

--- a/nifty-controls/src/main/java/de/lessvoid/nifty/controls/RadioButtonStateChangedEvent.java
+++ b/nifty-controls/src/main/java/de/lessvoid/nifty/controls/RadioButtonStateChangedEvent.java
@@ -10,7 +10,7 @@ import de.lessvoid.nifty.NiftyEvent;
  * RadioGroupSelectionChangedEvent. 
  * @author void
  */
-public class RadioButtonStateChangedEvent implements NiftyEvent<Void> {
+public class RadioButtonStateChangedEvent implements NiftyEvent {
   private RadioButton radioButton;
   private boolean selected;
 

--- a/nifty-controls/src/main/java/de/lessvoid/nifty/controls/ScrollPanelChangedEvent.java
+++ b/nifty-controls/src/main/java/de/lessvoid/nifty/controls/ScrollPanelChangedEvent.java
@@ -6,7 +6,7 @@ import de.lessvoid.nifty.NiftyEvent;
  * Nifty generates this event when a ScrollPanel position has changed.
  * @author void
  */
-public class ScrollPanelChangedEvent implements NiftyEvent<Void> {
+public class ScrollPanelChangedEvent implements NiftyEvent {
   private ScrollPanel scrollPanel;
   private float x;
   private float y;

--- a/nifty-controls/src/main/java/de/lessvoid/nifty/controls/ScrollbarChangedEvent.java
+++ b/nifty-controls/src/main/java/de/lessvoid/nifty/controls/ScrollbarChangedEvent.java
@@ -6,7 +6,7 @@ import de.lessvoid.nifty.NiftyEvent;
  * Nifty generates this event when a Scrollbar value has been changed.
  * @author void
  */
-public class ScrollbarChangedEvent implements NiftyEvent<Void> {
+public class ScrollbarChangedEvent implements NiftyEvent {
   private Scrollbar scrollbar;
   private float value;
 

--- a/nifty-controls/src/main/java/de/lessvoid/nifty/controls/SliderChangedEvent.java
+++ b/nifty-controls/src/main/java/de/lessvoid/nifty/controls/SliderChangedEvent.java
@@ -6,7 +6,7 @@ import de.lessvoid.nifty.NiftyEvent;
  * Nifty generates this event when a Slider value has been changed.
  * @author void
  */
-public class SliderChangedEvent implements NiftyEvent<Void> {
+public class SliderChangedEvent implements NiftyEvent {
   private Slider slider;
   private float value;
 

--- a/nifty-controls/src/main/java/de/lessvoid/nifty/controls/TabSelectedEvent.java
+++ b/nifty-controls/src/main/java/de/lessvoid/nifty/controls/TabSelectedEvent.java
@@ -11,7 +11,7 @@ import de.lessvoid.nifty.controls.tabs.TabsControl;
  *
  * @author ractoc
  */
-public class TabSelectedEvent implements NiftyEvent<Void> {
+public class TabSelectedEvent implements NiftyEvent {
     private TabsControl tabsControl;
     private String selectedTabId;
     

--- a/nifty-controls/src/main/java/de/lessvoid/nifty/controls/TextFieldChangedEvent.java
+++ b/nifty-controls/src/main/java/de/lessvoid/nifty/controls/TextFieldChangedEvent.java
@@ -6,7 +6,7 @@ import de.lessvoid.nifty.NiftyEvent;
  * Nifty generates this event when the current text of an TextField changes.
  * @author void
  */
-public class TextFieldChangedEvent implements NiftyEvent<Void> {
+public class TextFieldChangedEvent implements NiftyEvent {
   private TextField textField;
   private String currentText;
 

--- a/nifty-controls/src/main/java/de/lessvoid/nifty/controls/TreeBox.java
+++ b/nifty-controls/src/main/java/de/lessvoid/nifty/controls/TreeBox.java
@@ -7,7 +7,7 @@ package de.lessvoid.nifty.controls;
 /**
  * @author ractoc
  */
-public interface TreeBox extends NiftyControl {
+public interface TreeBox<T> extends NiftyControl {
     
-    void setTree(TreeItem treeRoot);
+    void setTree(TreeItem<T> treeRoot);
 }

--- a/nifty-controls/src/main/java/de/lessvoid/nifty/controls/TreeItem.java
+++ b/nifty-controls/src/main/java/de/lessvoid/nifty/controls/TreeItem.java
@@ -32,20 +32,20 @@ public class TreeItem<T> {
     }
 
     public TreeItem(TreeItem<T> parentItem, T value, String displayCaption, NiftyImage displayIconCollapsed, NiftyImage displayIconExpanded) {
-        this(parentItem, value, displayCaption, displayIconCollapsed, displayIconExpanded, false);
-    }
+      this(parentItem, value, displayCaption, displayIconCollapsed, displayIconExpanded, false);
+  }
 
     public TreeItem(TreeItem<T> parentItem, T value, String displayCaption, NiftyImage displayIcon, boolean expanded) {
-        this(parentItem, value, displayCaption, displayIcon, null, expanded);
-    }
+      this(parentItem, value, displayCaption, displayIcon, null, expanded);
+  }
 
     public TreeItem(TreeItem<T> parentItem, T value, String displayCaption, NiftyImage displayIcon) {
-        this(parentItem, value, displayCaption, displayIcon, null, false);
-    }
-    
+      this(parentItem, value, displayCaption, displayIcon, null, false);
+  }
+
     public TreeItem() {
-        this(null, null, "Root", null, null, true);
-    }
+      this(null, null, "Root", null, null, true);
+  }
 
     public void addTreeItem(TreeItem<T> item) {
         treeNodes.add(item);
@@ -123,7 +123,7 @@ public class TreeItem<T> {
         } else if (treeNodes.contains(child)) {
             return true;
         } else {
-            for (TreeItem item : treeNodes) {
+            for (TreeItem<T> item : treeNodes) {
                 boolean found = item.contains(child);
                 if (found) {
                     return true;

--- a/nifty-controls/src/main/java/de/lessvoid/nifty/controls/TreeItemSelectedEvent.java
+++ b/nifty-controls/src/main/java/de/lessvoid/nifty/controls/TreeItemSelectedEvent.java
@@ -11,33 +11,33 @@ import de.lessvoid.nifty.controls.treebox.TreeBoxControl;
  *
  * @author ractoc
  */
-public class TreeItemSelectedEvent implements NiftyEvent<Void> {
+public class TreeItemSelectedEvent<T> implements NiftyEvent {
     
-    private TreeBoxControl treeBoxControl;
-    private TreeItem treeItem;
+    private TreeBoxControl<T> treeBoxControl;
+    private TreeItem<T> treeItem;
 
-    public TreeItemSelectedEvent(TreeBoxControl treeBoxControl, TreeItem treeItem) {
+    public TreeItemSelectedEvent(TreeBoxControl<T> treeBoxControl, TreeItem<T> treeItem) {
         this.treeBoxControl = treeBoxControl;
         this.treeItem = treeItem;
     }
 
-    public TreeItemSelectedEvent(TreeItem treeItem) {
+    public TreeItemSelectedEvent(TreeItem<T> treeItem) {
         this.treeItem = treeItem;
     }
 
-    public TreeBoxControl getTreeBoxControl() {
+    public TreeBoxControl<T> getTreeBoxControl() {
         return treeBoxControl;
     }
 
-    public void setTreeBoxControl(TreeBoxControl treeBoxControl) {
+    public void setTreeBoxControl(TreeBoxControl<T> treeBoxControl) {
         this.treeBoxControl = treeBoxControl;
     }
 
-    public TreeItem getTreeItem() {
+    public TreeItem<T> getTreeItem() {
         return treeItem;
     }
 
-    public void setTreeItem(TreeItem treeItem) {
+    public void setTreeItem(TreeItem<T> treeItem) {
         this.treeItem = treeItem;
     }
     

--- a/nifty-controls/src/main/java/de/lessvoid/nifty/controls/dropdown/DropDownControl.java
+++ b/nifty-controls/src/main/java/de/lessvoid/nifty/controls/dropdown/DropDownControl.java
@@ -54,15 +54,14 @@ public class DropDownControl<T> extends AbstractController implements DropDown<T
     listBox = popup.findNiftyControl("#listBox", ListBox.class);
   }
 
-  @SuppressWarnings("rawtypes")
   public void onStartScreen() {
     updateEnabled();
 
-    ListBoxControl listBoxControl = (ListBoxControl) listBox;
+    ListBoxControl <T> listBoxControl = (ListBoxControl<T>) listBox;
     listBoxControl.getViewConverter().display(getElement().findElementByName("#text"), getSelection());
 
     nifty.subscribe(screen, listBox.getId(), ListBoxSelectionChangedEvent.class,
-        new DropDownListBoxSelectionChangedEventSubscriber(nifty, screen, listBox, this, popup));
+        new DropDownListBoxSelectionChangedEventSubscriber<T>(nifty, screen, listBox, this, popup));
   }
 
   public boolean inputEvent(final NiftyInputEvent inputEvent) {
@@ -115,7 +114,7 @@ public class DropDownControl<T> extends AbstractController implements DropDown<T
         // when the popup is closed Nifty will automatically remove all subscribers for all controls in the popup.
         // this is in general the right behaviour, since the controls are gone (the popup is closed). However in this
         // case here the listbox is still used by the DropDown. So we need to subscribe our listener again.
-        nifty.subscribe(screen, listBox.getId(), ListBoxSelectionChangedEvent.class, new DropDownListBoxSelectionChangedEventSubscriber(nifty, screen, listBox, DropDownControl.this, popup));
+        nifty.subscribe(screen, listBox.getId(), ListBoxSelectionChangedEvent.class, new DropDownListBoxSelectionChangedEventSubscriber<T>(nifty, screen, listBox, DropDownControl.this, popup));
         if (endNotify != null) {
           endNotify.perform();
         }

--- a/nifty-controls/src/main/java/de/lessvoid/nifty/controls/dropdown/DropDownListBoxSelectionChangedEventSubscriber.java
+++ b/nifty-controls/src/main/java/de/lessvoid/nifty/controls/dropdown/DropDownListBoxSelectionChangedEventSubscriber.java
@@ -10,18 +10,17 @@ import de.lessvoid.nifty.controls.DropDown;
 import de.lessvoid.nifty.controls.DropDownSelectionChangedEvent;
 import de.lessvoid.nifty.controls.ListBox;
 import de.lessvoid.nifty.controls.ListBoxSelectionChangedEvent;
-import de.lessvoid.nifty.controls.listbox.ListBoxControl;
 import de.lessvoid.nifty.elements.Element;
 import de.lessvoid.nifty.screen.Screen;
 
-public class DropDownListBoxSelectionChangedEventSubscriber implements EventTopicSubscriber<ListBoxSelectionChangedEvent> {
+public class DropDownListBoxSelectionChangedEventSubscriber<T> implements EventTopicSubscriber<ListBoxSelectionChangedEvent<T>> {
   private Nifty nifty;
   private Screen screen;
-  private ListBox listBox;
-  private DropDown dropDown;
+  private ListBox<T> listBox;
+  private DropDown<T> dropDown;
   private Element popupInstance;
 
-  public DropDownListBoxSelectionChangedEventSubscriber(final Nifty nifty, final Screen screen, final ListBox listBox, final DropDown dropDown, final Element popupInstance) {
+  public DropDownListBoxSelectionChangedEventSubscriber(final Nifty nifty, final Screen screen, final ListBox<T> listBox, final DropDown<T> dropDown, final Element popupInstance) {
     this.nifty = nifty;
     this.screen = screen;
     this.listBox = listBox;
@@ -29,12 +28,11 @@ public class DropDownListBoxSelectionChangedEventSubscriber implements EventTopi
     this.popupInstance = popupInstance;
   }
 
-  @SuppressWarnings("unchecked")
   @Override
-  public void onEvent(final String topic, final ListBoxSelectionChangedEvent data) {
-    final Object selectedItem = getSelectedItem(data.getSelection());
+  public void onEvent(final String topic, final ListBoxSelectionChangedEvent<T> data) {
+    final T selectedItem = getSelectedItem(data.getSelection());
 
-    ListBoxControl listBoxControl = (ListBoxControl) listBox;
+    de.lessvoid.nifty.controls.listbox.ListBoxControl<T> listBoxControl = (de.lessvoid.nifty.controls.listbox.ListBoxControl<T>) listBox;
     listBoxControl.getViewConverter().display(dropDown.getElement().findElementByName("#text"), selectedItem);
 
     final int selectedItemIndex = getSelectedIndex(data);
@@ -42,15 +40,15 @@ public class DropDownListBoxSelectionChangedEventSubscriber implements EventTopi
       dropDown.getElement().getControl(DropDownControl.class).close(new EndNotify() {
         @Override
         public void perform() {
-          nifty.publishEvent(dropDown.getId(), new DropDownSelectionChangedEvent(dropDown, selectedItem, selectedItemIndex));
+          nifty.publishEvent(dropDown.getId(), new DropDownSelectionChangedEvent<T>(dropDown, selectedItem, selectedItemIndex));
         }
       });
     } else {
-      nifty.publishEvent(dropDown.getId(), new DropDownSelectionChangedEvent(dropDown, selectedItem, selectedItemIndex));
+      nifty.publishEvent(dropDown.getId(), new DropDownSelectionChangedEvent<T>(dropDown, selectedItem, selectedItemIndex));
     }
   }
 
-  private int getSelectedIndex(final ListBoxSelectionChangedEvent data) {
+  private int getSelectedIndex(final ListBoxSelectionChangedEvent<T> data) {
     int selectedItemIndex = -1;
     List<Integer> selectionIndices = data.getSelectionIndices();
     if (!selectionIndices.isEmpty()) {
@@ -59,7 +57,7 @@ public class DropDownListBoxSelectionChangedEventSubscriber implements EventTopi
     return selectedItemIndex;
   }
 
-  private Object getSelectedItem(final List selection) {
+  private T getSelectedItem(final List<T> selection) {
     if (selection.isEmpty()) {
       return null;
     }

--- a/nifty-controls/src/main/java/de/lessvoid/nifty/controls/dropdown/DropDownPopup.java
+++ b/nifty-controls/src/main/java/de/lessvoid/nifty/controls/dropdown/DropDownPopup.java
@@ -3,12 +3,8 @@ package de.lessvoid.nifty.controls.dropdown;
 import java.util.List;
 import java.util.Properties;
 
-import org.bushe.swing.event.EventTopicSubscriber;
-
-import de.lessvoid.nifty.EndNotify;
 import de.lessvoid.nifty.Nifty;
 import de.lessvoid.nifty.controls.AbstractController;
-import de.lessvoid.nifty.controls.DropDownSelectionChangedEvent;
 import de.lessvoid.nifty.controls.ListBox;
 import de.lessvoid.nifty.controls.ListBoxSelectionChangedEvent;
 import de.lessvoid.nifty.controls.listbox.ListBoxControl;
@@ -52,21 +48,23 @@ public class DropDownPopup<T> extends AbstractController {
 
   @SuppressWarnings("deprecation")
   public void onStartScreen() {
-    final ListBox listBox = getElement().findNiftyControl("#listBox", ListBoxControl.class);
+    @SuppressWarnings ("unchecked")
+    final ListBox<T> listBox = getElement().findNiftyControl("#listBox", ListBoxControl.class);
     nifty.subscribe(screen, listBox.getId(), ListBoxSelectionChangedEvent.class,
-        new DropDownListBoxSelectionChangedEventSubscriber(nifty, screen, listBox, dropDownControl, popupInstance));
+        new DropDownListBoxSelectionChangedEventSubscriber<T>(nifty, screen, listBox, dropDownControl, popupInstance));
     linkPopupToDropDownPosition(dropDownControl);
     dropDownControl.refresh();
   }
 
-  @SuppressWarnings({ "deprecation", "rawtypes" })
+  @SuppressWarnings("deprecation")
   private void linkPopupToDropDownPosition(final DropDownControl<T> dropDownControl) {
     Element panel = getElement().findElementByName("#panel");
     panel.setConstraintX(new SizeValue(dropDownControl.getElement().getX() + "px"));
     panel.setConstraintWidth(new SizeValue(dropDownControl.getWidth() + "px"));
     getElement().layoutElements();
 
-    ListBoxControl listBox = getElement().findNiftyControl("#listBox", ListBoxControl.class);
+    @SuppressWarnings ("unchecked")
+    ListBoxControl<T> listBox = getElement().findNiftyControl("#listBox", ListBoxControl.class);
     listBox.ensureWidthConstraints();
 
     panel.setConstraintHeight(new SizeValue(listBox.getHeight() + "px"));
@@ -81,8 +79,8 @@ public class DropDownPopup<T> extends AbstractController {
     getElement().layoutElements();
   }
 
-  @SuppressWarnings({ "deprecation", "rawtypes" })
-  private void updateMoveEffect(final ListBoxControl listBox, final int direction) {
+  @SuppressWarnings("deprecation")
+  private void updateMoveEffect(final ListBoxControl<T> listBox, final int direction) {
     List<Effect> moveEffects = getElement().findElementByName("#panel").getEffects(EffectEventId.onStartScreen, Move.class);
     if (!moveEffects.isEmpty()) {
       moveEffects.get(0).getParameters().setProperty("offsetY", String.valueOf(direction * listBox.getHeight()));

--- a/nifty-controls/src/main/java/de/lessvoid/nifty/controls/imageselect/builder/CreateImageSelectControl.java
+++ b/nifty-controls/src/main/java/de/lessvoid/nifty/controls/imageselect/builder/CreateImageSelectControl.java
@@ -20,7 +20,6 @@ public class CreateImageSelectControl extends ControlAttributes {
     setName("imageSelect");
   }
 
-  @SuppressWarnings("rawtypes")
   public ImageSelect create(
       final Nifty nifty,
       final Screen screen,

--- a/nifty-controls/src/main/java/de/lessvoid/nifty/controls/listbox/builder/CreateListBoxControl.java
+++ b/nifty-controls/src/main/java/de/lessvoid/nifty/controls/listbox/builder/CreateListBoxControl.java
@@ -4,13 +4,12 @@ import de.lessvoid.nifty.Nifty;
 import de.lessvoid.nifty.NiftyIdCreator;
 import de.lessvoid.nifty.controls.ListBox;
 import de.lessvoid.nifty.controls.dynamic.attributes.ControlAttributes;
-import de.lessvoid.nifty.controls.listbox.ListBoxControl;
 import de.lessvoid.nifty.elements.Element;
 import de.lessvoid.nifty.loaderv2.types.ControlType;
 import de.lessvoid.nifty.loaderv2.types.ElementType;
 import de.lessvoid.nifty.screen.Screen;
 
-public class CreateListBoxControl extends ControlAttributes {
+public class CreateListBoxControl<T> extends ControlAttributes {
   public CreateListBoxControl() {
     setAutoId(NiftyIdCreator.generate());
     setName("listBox");
@@ -21,14 +20,15 @@ public class CreateListBoxControl extends ControlAttributes {
     setName("listBox");
   }
 
-  @SuppressWarnings("rawtypes")
-  public ListBox create(
+  public ListBox<T> create(
       final Nifty nifty,
       final Screen screen,
       final Element parent) {
     nifty.addControl(screen, parent, getStandardControl());
     nifty.addControlsWithoutStartScreen();
-    return parent.findNiftyControl(attributes.get("id"), ListBoxControl.class);
+    @SuppressWarnings ("unchecked")
+    ListBox<T> result = parent.findNiftyControl(attributes.get("id"), ListBox.class);
+    return result;
   }
 
   @Override

--- a/nifty-controls/src/main/java/de/lessvoid/nifty/controls/menu/MenuControl.java
+++ b/nifty-controls/src/main/java/de/lessvoid/nifty/controls/menu/MenuControl.java
@@ -4,7 +4,6 @@ import java.util.Hashtable;
 import java.util.Map;
 import java.util.Properties;
 
-import de.lessvoid.nifty.EndNotify;
 import de.lessvoid.nifty.Nifty;
 import de.lessvoid.nifty.NiftyIdCreator;
 import de.lessvoid.nifty.builder.ControlBuilder;

--- a/nifty-controls/src/main/java/de/lessvoid/nifty/controls/nullobjects/DropDownNull.java
+++ b/nifty-controls/src/main/java/de/lessvoid/nifty/controls/nullobjects/DropDownNull.java
@@ -6,7 +6,7 @@ import de.lessvoid.nifty.controls.DropDown;
 import de.lessvoid.nifty.elements.Element;
 import de.lessvoid.nifty.tools.SizeValue;
 
-public class DropDownNull implements DropDown {
+public class DropDownNull<T> implements DropDown<T> {
 
   @Override
   public Element getElement() {
@@ -67,15 +67,15 @@ public class DropDownNull implements DropDown {
   }
 
   @Override
-  public void setViewConverter(final DropDownViewConverter viewConverter) {
+  public void setViewConverter(final DropDownViewConverter<T> viewConverter) {
   }
 
   @Override
-  public void addItem(final Object newItem) {
+  public void addItem(final T newItem) {
   }
 
   @Override
-  public void insertItem(final Object item, final int index) {
+  public void insertItem(final T item, final int index) {
   }
 
   @Override
@@ -92,11 +92,11 @@ public class DropDownNull implements DropDown {
   }
 
   @Override
-  public void selectItem(final Object item) {
+  public void selectItem(final T item) {
   }
 
   @Override
-  public Object getSelection() {
+  public T getSelection() {
     return null;
   }
 
@@ -110,20 +110,20 @@ public class DropDownNull implements DropDown {
   }
 
   @Override
-  public void removeItem(final Object item) {
+  public void removeItem(final T item) {
   }
 
   @Override
-  public List getItems() {
+  public List<T> getItems() {
     return null;
   }
 
   @Override
-  public void addAllItems(final List itemsToAdd) {
+  public void addAllItems(final List<T> itemsToAdd) {
   }
 
   @Override
-  public void removeAllItems(final List itemsToRemove) {
+  public void removeAllItems(final List<T> itemsToRemove) {
   }
 
   @Override

--- a/nifty-controls/src/main/java/de/lessvoid/nifty/controls/nullobjects/ListBoxNull.java
+++ b/nifty-controls/src/main/java/de/lessvoid/nifty/controls/nullobjects/ListBoxNull.java
@@ -8,7 +8,7 @@ import de.lessvoid.nifty.controls.ListBox;
 import de.lessvoid.nifty.elements.Element;
 import de.lessvoid.nifty.tools.SizeValue;
 
-public class ListBoxNull implements ListBox {
+public class ListBoxNull<T> implements ListBox<T> {
 
   @Override
   public Element getElement() {
@@ -73,15 +73,15 @@ public class ListBoxNull implements ListBox {
   }
 
   @Override
-  public void setListBoxViewConverter(final ListBoxViewConverter viewConverter) {
+  public void setListBoxViewConverter(final ListBoxViewConverter<T> viewConverter) {
   }
 
   @Override
-  public void addItem(final Object newItem) {
+  public void addItem(final T newItem) {
   }
 
   @Override
-  public void insertItem(final Object item, final int index) {
+  public void insertItem(final T item, final int index) {
   }
 
   @Override
@@ -98,7 +98,7 @@ public class ListBoxNull implements ListBox {
   }
 
   @Override
-  public void selectItem(final Object item) {
+  public void selectItem(final T item) {
   }
 
   @Override
@@ -114,11 +114,11 @@ public class ListBoxNull implements ListBox {
   }
 
   @Override
-  public void deselectItem(final Object item) {
+  public void deselectItem(final T item) {
   }
 
   @Override
-  public List getSelection() {
+  public List<T> getSelection() {
     return null;
   }
 
@@ -127,16 +127,16 @@ public class ListBoxNull implements ListBox {
   }
 
   @Override
-  public void removeItem(final Object item) {
+  public void removeItem(final T item) {
   }
 
   @Override
-  public List getItems() {
+  public List<T> getItems() {
     return null;
   }
 
   @Override
-  public void showItem(final Object item) {
+  public void showItem(final T item) {
   }
 
   @Override
@@ -144,7 +144,7 @@ public class ListBoxNull implements ListBox {
   }
 
   @Override
-  public void setFocusItem(final Object item) {
+  public void setFocusItem(final T item) {
   }
 
   @Override
@@ -152,7 +152,7 @@ public class ListBoxNull implements ListBox {
   }
 
   @Override
-  public Object getFocusItem() {
+  public T getFocusItem() {
     return null;
   }
 
@@ -162,11 +162,11 @@ public class ListBoxNull implements ListBox {
   }
 
   @Override
-  public void addAllItems(final List itemsToAdd) {
+  public void addAllItems(final List<T> itemsToAdd) {
   }
 
   @Override
-  public void removeAllItems(final List itemsToRemove) {
+  public void removeAllItems(final List<T> itemsToRemove) {
   }
 
   @Override
@@ -174,7 +174,7 @@ public class ListBoxNull implements ListBox {
   }
 
   @Override
-  public void sortAllItems(final Comparator comperator) {
+  public void sortAllItems(final Comparator<T> comperator) {
   }
 
   @Override

--- a/nifty-controls/src/main/java/de/lessvoid/nifty/controls/treebox/TreeBoxControl.java
+++ b/nifty-controls/src/main/java/de/lessvoid/nifty/controls/treebox/TreeBoxControl.java
@@ -23,13 +23,13 @@ import de.lessvoid.xml.xpp3.Attributes;
  * 
  * @author ractoc
  */
-public class TreeBoxControl extends AbstractController implements TreeBox {
+public class TreeBoxControl<T> extends AbstractController implements TreeBox<T> {
 
 	private int indentWidth = 15;
-	private TreeItem tree;
+	private TreeItem<T> tree;
 	private Nifty nifty;
 	private Element element;
-	private ListBox<TreeEntryModelClass> treeListBox;
+	private ListBox<TreeEntryModelClass<T>> treeListBox;
 	private boolean processingItemSelected;
 
 	@Override
@@ -58,7 +58,7 @@ public class TreeBoxControl extends AbstractController implements TreeBox {
 	}
 
 	@Override
-	public void setTree(TreeItem treeRoot) {
+	public void setTree(TreeItem<T> treeRoot) {
 		this.tree = treeRoot;
 		treeListBox.clear();
 		if (treeListBox != null) {
@@ -73,19 +73,19 @@ public class TreeBoxControl extends AbstractController implements TreeBox {
 	 */
 	@NiftyEventSubscriber(id = "tree-box#listbox")
 	public void onListBoxSelectionChanged(final String id,
-			final ListBoxSelectionChangedEvent<TreeEntryModelClass> event) {
+			final ListBoxSelectionChangedEvent<TreeEntryModelClass<T>> event) {
 		if (!processingItemSelected) {
 			processingItemSelected = true;
-			TreeEntryModelClass selectedItem = event.getSelection().get(0);
+			TreeEntryModelClass<T> selectedItem = event.getSelection().get(0);
 			Integer selectedIndex = event.getSelectionIndices().get(0);
-			TreeItem item = selectedItem.getTreeItem();
+			TreeItem<T> item = selectedItem.getTreeItem();
 			if (!item.isLeaf() && selectedItem.isActiveItem()) {
 				item.setExpanded(!item.isExpanded());
 			}
 			selectedItem.setActiveItem(true);
 			setTree(tree);
 			treeListBox.getItems().get(selectedIndex).setActiveItem(true);
-			nifty.publishEvent(getId(), new TreeItemSelectedEvent(this, item));
+			nifty.publishEvent(getId(), new TreeItemSelectedEvent<T>(this, item));
 			treeListBox.refresh();
 			processingItemSelected = false;
 		}
@@ -95,21 +95,21 @@ public class TreeBoxControl extends AbstractController implements TreeBox {
 	@SuppressWarnings("unchecked")
 	private void setListBox(final String name) {
 		if (treeListBox == null) {
-			treeListBox = (ListBox<TreeEntryModelClass>) element
+			treeListBox = (ListBox<TreeEntryModelClass<T>>) element
 					.findNiftyControl(name, ListBox.class);
 		}
 	}
 
-	private int addTreeItem(ListBox<TreeEntryModelClass> treeListBox,
-			TreeItem treeItem, int currentIndent, int itemIndex) {
+	private int addTreeItem(ListBox<TreeEntryModelClass<T>> treeListBox,
+			TreeItem<T> treeItem, int currentIndent, int itemIndex) {
 		if (currentIndent != 0) {
-			treeListBox.insertItem(new TreeEntryModelClass(indentWidth
+			treeListBox.insertItem(new TreeEntryModelClass<T>(indentWidth
 					* currentIndent, treeItem), itemIndex);
 			itemIndex++;
 		}
 		if (treeItem.isExpanded()) {
-			for (Object childItem : treeItem.getTreeItems()) {
-				itemIndex = addTreeItem(treeListBox, (TreeItem) childItem,
+			for (TreeItem<T> childItem : treeItem.getTreeItems()) {
+				itemIndex = addTreeItem(treeListBox, childItem,
 						currentIndent + 1, itemIndex);
 			}
 		}
@@ -117,8 +117,8 @@ public class TreeBoxControl extends AbstractController implements TreeBox {
 	}
 
 	private void removeAbsoleteTreeItems(
-			ListBox<TreeEntryModelClass> treeListBox, TreeItem tree) {
-		for (TreeEntryModelClass treeListEntry : treeListBox.getItems()) {
+			ListBox<TreeEntryModelClass<T>> treeListBox, TreeItem<T> tree) {
+		for (TreeEntryModelClass<T> treeListEntry : treeListBox.getItems()) {
 			treeListEntry.setActiveItem(false);
 			if (!tree.contains(treeListEntry.getTreeItem())) {
 				treeListBox.removeItem(treeListEntry);

--- a/nifty-controls/src/main/java/de/lessvoid/nifty/controls/treebox/TreeBoxViewConverter.java
+++ b/nifty-controls/src/main/java/de/lessvoid/nifty/controls/treebox/TreeBoxViewConverter.java
@@ -14,10 +14,10 @@ import de.lessvoid.nifty.tools.SizeValue;
  *
  * @author ractoc
  */
-public class TreeBoxViewConverter implements ListBoxViewConverter<TreeEntryModelClass> {
+public class TreeBoxViewConverter implements ListBoxViewConverter<TreeEntryModelClass<?>> {
 
     @Override
-    public void display(Element listBoxItem, TreeEntryModelClass item) {
+    public void display(Element listBoxItem, TreeEntryModelClass<?> item) {
         final Element spacer = listBoxItem.findElementByName("#tree-item-spacer");
         spacer.setConstraintWidth(new SizeValue(String.valueOf(item.getIndent())));
         spacer.setConstraintHeight(new SizeValue(String.valueOf(item.getTreeItem().getDisplayIconCollapsed().getHeight())));
@@ -42,7 +42,7 @@ public class TreeBoxViewConverter implements ListBoxViewConverter<TreeEntryModel
     }
 
     @Override
-    public int getWidth(Element element, TreeEntryModelClass item) {
+    public int getWidth(Element element, TreeEntryModelClass<?> item) {
         final Element text = element.findElementByName("#tree-item-caption");
         final TextRenderer textRenderer = text.getRenderer(TextRenderer.class);
         return ((textRenderer.getFont() == null) ? 0 : textRenderer.getFont().getWidth(item.getTreeItem().getDisplayCaption())

--- a/nifty-controls/src/main/java/de/lessvoid/nifty/controls/treebox/TreeEntryModelClass.java
+++ b/nifty-controls/src/main/java/de/lessvoid/nifty/controls/treebox/TreeEntryModelClass.java
@@ -10,15 +10,15 @@ import de.lessvoid.nifty.controls.TreeItem;
  *
  * @author ractoc
  */
-public class TreeEntryModelClass {
+public class TreeEntryModelClass<T> {
    
-    private TreeItem treeItem;
+    private TreeItem<T> treeItem;
     
     private int indent;
     
     private boolean activeItem;
     
-    public TreeEntryModelClass(int indent, TreeItem treeItem) {
+    public TreeEntryModelClass(int indent, TreeItem<T> treeItem) {
         this.indent = indent;
         this.treeItem = treeItem;
     }
@@ -39,7 +39,7 @@ public class TreeEntryModelClass {
         if (obj == null || !(obj instanceof TreeEntryModelClass)) {
             return false;
         }
-        return this.treeItem.equals(((TreeEntryModelClass) obj).getTreeItem());
+        return this.treeItem.equals(((TreeEntryModelClass<?>) obj).getTreeItem());
     }
 
     /**
@@ -66,11 +66,11 @@ public class TreeEntryModelClass {
         this.indent = indent;
     }
 
-    public TreeItem getTreeItem() {
+    public TreeItem<T> getTreeItem() {
         return treeItem;
     }
 
-    public void setTreeItem(TreeItem treeItem) {
+    public void setTreeItem(TreeItem<T> treeItem) {
         this.treeItem = treeItem;
     }
     

--- a/nifty-controls/src/test/java/de/lessvoid/nifty/controls/ListBoxMultipleSelectionViewTest.java
+++ b/nifty-controls/src/test/java/de/lessvoid/nifty/controls/ListBoxMultipleSelectionViewTest.java
@@ -4,7 +4,6 @@ import static org.easymock.EasyMock.capture;
 import static org.easymock.classextension.EasyMock.createMock;
 import static org.easymock.classextension.EasyMock.replay;
 import static org.easymock.classextension.EasyMock.verify;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;

--- a/nifty-controls/src/test/java/de/lessvoid/nifty/controls/listbox/ListBoxFocusElementEmptyTest.java
+++ b/nifty-controls/src/test/java/de/lessvoid/nifty/controls/listbox/ListBoxFocusElementEmptyTest.java
@@ -2,8 +2,6 @@ package de.lessvoid.nifty.controls.listbox;
 
 import static org.easymock.EasyMock.expect;
 import static org.easymock.classextension.EasyMock.*;
-import static org.easymock.classextension.EasyMock.replay;
-import static org.easymock.classextension.EasyMock.verify;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
@@ -95,6 +93,7 @@ public class ListBoxFocusElementEmptyTest {
     assertEquals(o2, listBox.getFocusItem());
   }
 
+  @SuppressWarnings ("unchecked")
   @Test
   public void testGetFocusAfterClear() {
     expect(viewMock.getWidth(o1)).andReturn(WIDTH_100);
@@ -116,6 +115,7 @@ public class ListBoxFocusElementEmptyTest {
     assertNull(listBox.getFocusItem());
   }
 
+  @SuppressWarnings ("unchecked")
   @Test
   public void testGetFocusAfterRemoveItem() {
     expect(viewMock.getWidth(o1)).andReturn(WIDTH_100);
@@ -133,6 +133,7 @@ public class ListBoxFocusElementEmptyTest {
     assertNull(listBox.getFocusItem());
   }
 
+  @SuppressWarnings ("unchecked")
   @Test
   public void testGetFocusAfterRemoveItemByIndex() {
     expect(viewMock.getWidth(o1)).andReturn(WIDTH_100);

--- a/nifty-controls/src/test/java/de/lessvoid/nifty/controls/listbox/ListBoxFocusElementTest.java
+++ b/nifty-controls/src/test/java/de/lessvoid/nifty/controls/listbox/ListBoxFocusElementTest.java
@@ -115,6 +115,7 @@ public class ListBoxFocusElementTest {
     assertEquals(0, listBox.getFocusItemIndex());
   }
 
+  @SuppressWarnings ("unchecked")
   @Test
   public void testFocusItemAfterDelete() {
     viewMock.updateTotalCount(3);
@@ -128,6 +129,7 @@ public class ListBoxFocusElementTest {
     assertEquals(o2, listBox.getFocusItem());
   }
 
+  @SuppressWarnings ("unchecked")
   @Test
   public void testRemoveFocusItemBeingTheLastItem() {
     viewMock.scrollTo(2);

--- a/nifty-controls/src/test/java/de/lessvoid/nifty/controls/listbox/ListBoxItemRemoveTest.java
+++ b/nifty-controls/src/test/java/de/lessvoid/nifty/controls/listbox/ListBoxItemRemoveTest.java
@@ -37,6 +37,7 @@ public class ListBoxItemRemoveTest {
     verify(viewMock);
   }
 
+  @SuppressWarnings ("unchecked")
   @Test
   public void testClear() {
     viewMock.updateTotalCount(0);
@@ -49,6 +50,7 @@ public class ListBoxItemRemoveTest {
     assertListBoxCount(0);
   }
 
+  @SuppressWarnings ("unchecked")
   @Test
   public void testRemoveItemByIndex() {
     viewMock.updateTotalCount(1);
@@ -77,6 +79,7 @@ public class ListBoxItemRemoveTest {
     assertListBoxCount(2);
   }
 
+  @SuppressWarnings ("unchecked")
   @Test
   public void testRemoveAllItemManual() {
     viewMock.updateTotalCount(1);
@@ -93,6 +96,7 @@ public class ListBoxItemRemoveTest {
     assertListBoxCount(0);
   }
 
+  @SuppressWarnings ("unchecked")
   @Test
   public void testRemoveAllItems() {
     viewMock.updateTotalCount(0);
@@ -108,6 +112,7 @@ public class ListBoxItemRemoveTest {
     assertListBoxCount(0);
   }
 
+  @SuppressWarnings ("unchecked")
   @Test
   public void testRemoveAllItemsAtBackOfList() {
     TestItem o3 = new TestItem("o3");

--- a/nifty-core/.settings/org.eclipse.jdt.core.prefs
+++ b/nifty-core/.settings/org.eclipse.jdt.core.prefs
@@ -1,6 +1,4 @@
-#Sat Jul 16 22:20:31 CEST 2011
 eclipse.preferences.version=1
 org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.6
 org.eclipse.jdt.core.compiler.compliance=1.6
-org.eclipse.jdt.core.compiler.problem.forbiddenReference=warning
 org.eclipse.jdt.core.compiler.source=1.6

--- a/nifty-core/src/main/java/de/lessvoid/nifty/Nifty.java
+++ b/nifty-core/src/main/java/de/lessvoid/nifty/Nifty.java
@@ -185,7 +185,6 @@ public class Nifty {
     return EventServiceLocator.getEventService("NiftyEventBus");
   }
 
-  @SuppressWarnings("rawtypes")
   public void publishEvent(final String id, final NiftyEvent event) {
     // we can't publish events for elements without an id
     if (id != null) {

--- a/nifty-core/src/main/java/de/lessvoid/nifty/NiftyDefaults.java
+++ b/nifty-core/src/main/java/de/lessvoid/nifty/NiftyDefaults.java
@@ -1,7 +1,5 @@
 package de.lessvoid.nifty;
 
-import java.util.logging.Logger;
-
 import de.lessvoid.nifty.loaderv2.types.RegisterEffectType;
 
 public class NiftyDefaults {

--- a/nifty-core/src/main/java/de/lessvoid/nifty/NiftyEvent.java
+++ b/nifty-core/src/main/java/de/lessvoid/nifty/NiftyEvent.java
@@ -4,5 +4,5 @@ package de.lessvoid.nifty;
  * Marker interface for NiftyEvents.
  * @author void
  */
-public interface NiftyEvent<T> {
+public interface NiftyEvent {
 }

--- a/nifty-core/src/main/java/de/lessvoid/nifty/controls/FocusGainedEvent.java
+++ b/nifty-core/src/main/java/de/lessvoid/nifty/controls/FocusGainedEvent.java
@@ -2,7 +2,7 @@ package de.lessvoid.nifty.controls;
 
 import de.lessvoid.nifty.NiftyEvent;
 
-public class FocusGainedEvent implements NiftyEvent<Void> {
+public class FocusGainedEvent implements NiftyEvent {
   private Controller controller;
   private NiftyControl niftyControl;
 

--- a/nifty-core/src/main/java/de/lessvoid/nifty/controls/FocusLostEvent.java
+++ b/nifty-core/src/main/java/de/lessvoid/nifty/controls/FocusLostEvent.java
@@ -2,7 +2,7 @@ package de.lessvoid.nifty.controls;
 
 import de.lessvoid.nifty.NiftyEvent;
 
-public class FocusLostEvent implements NiftyEvent<Void> {
+public class FocusLostEvent implements NiftyEvent {
   private Controller controller;
   private NiftyControl niftyControl;
 

--- a/nifty-core/src/main/java/de/lessvoid/nifty/effects/impl/SaveState.java
+++ b/nifty-core/src/main/java/de/lessvoid/nifty/effects/impl/SaveState.java
@@ -7,7 +7,6 @@ import de.lessvoid.nifty.effects.EffectProperties;
 import de.lessvoid.nifty.effects.Falloff;
 import de.lessvoid.nifty.elements.Element;
 import de.lessvoid.nifty.render.NiftyRenderEngine;
-import de.lessvoid.nifty.render.RenderStateType;
 
 /**
  * SaveState.

--- a/nifty-core/src/main/java/de/lessvoid/nifty/elements/Element.java
+++ b/nifty-core/src/main/java/de/lessvoid/nifty/elements/Element.java
@@ -57,7 +57,7 @@ import java.util.*;
  * The Element.
  * @author void
  */
-public class Element implements NiftyEvent<Void>, EffectManager.Notify {
+public class Element implements NiftyEvent, EffectManager.Notify {
 
   /**
    * the logger.

--- a/nifty-core/src/main/java/de/lessvoid/nifty/elements/PrimaryClickMouseMethods.java
+++ b/nifty-core/src/main/java/de/lessvoid/nifty/elements/PrimaryClickMouseMethods.java
@@ -49,7 +49,7 @@ public class PrimaryClickMouseMethods extends MouseClickMethods {
     return result;
   }
 
-  private void publishEvent(final Nifty nifty, final NiftyEvent<?> event) {
+  private void publishEvent(final Nifty nifty, final NiftyEvent event) {
     nifty.publishEvent(element.getId(), event);
   }
 }

--- a/nifty-core/src/main/java/de/lessvoid/nifty/elements/SecondaryClickMouseMethods.java
+++ b/nifty-core/src/main/java/de/lessvoid/nifty/elements/SecondaryClickMouseMethods.java
@@ -36,7 +36,7 @@ public class SecondaryClickMouseMethods extends MouseClickMethods {
     return super.onMouseRelease(nifty, mouseEvent);
   }
 
-  private void publishEvent(final Nifty nifty, final NiftyEvent<?> event) {
+  private void publishEvent(final Nifty nifty, final NiftyEvent event) {
     nifty.publishEvent(element.getId(), event);
   }
 }

--- a/nifty-core/src/main/java/de/lessvoid/nifty/elements/TertiaryClickMouseMethods.java
+++ b/nifty-core/src/main/java/de/lessvoid/nifty/elements/TertiaryClickMouseMethods.java
@@ -36,7 +36,7 @@ public class TertiaryClickMouseMethods extends MouseClickMethods {
     return super.onMouseRelease(nifty, mouseEvent);
   }
 
-  private void publishEvent(final Nifty nifty, final NiftyEvent<?> event) {
+  private void publishEvent(final Nifty nifty, final NiftyEvent event) {
     nifty.publishEvent(element.getId(), event);
   }
 }

--- a/nifty-core/src/main/java/de/lessvoid/nifty/elements/events/ElementDisableEvent.java
+++ b/nifty-core/src/main/java/de/lessvoid/nifty/elements/events/ElementDisableEvent.java
@@ -3,7 +3,7 @@ package de.lessvoid.nifty.elements.events;
 import de.lessvoid.nifty.NiftyEvent;
 import de.lessvoid.nifty.elements.Element;
 
-public class ElementDisableEvent implements NiftyEvent<Void> {
+public class ElementDisableEvent implements NiftyEvent {
   private Element element;
 
   public ElementDisableEvent(final Element element) {

--- a/nifty-core/src/main/java/de/lessvoid/nifty/elements/events/ElementEnableEvent.java
+++ b/nifty-core/src/main/java/de/lessvoid/nifty/elements/events/ElementEnableEvent.java
@@ -3,7 +3,7 @@ package de.lessvoid.nifty.elements.events;
 import de.lessvoid.nifty.NiftyEvent;
 import de.lessvoid.nifty.elements.Element;
 
-public class ElementEnableEvent implements NiftyEvent<Void> {
+public class ElementEnableEvent implements NiftyEvent {
   private Element element;
 
   public ElementEnableEvent(final Element element) {

--- a/nifty-core/src/main/java/de/lessvoid/nifty/elements/events/ElementHideEvent.java
+++ b/nifty-core/src/main/java/de/lessvoid/nifty/elements/events/ElementHideEvent.java
@@ -3,7 +3,7 @@ package de.lessvoid.nifty.elements.events;
 import de.lessvoid.nifty.NiftyEvent;
 import de.lessvoid.nifty.elements.Element;
 
-public class ElementHideEvent implements NiftyEvent<Void> {
+public class ElementHideEvent implements NiftyEvent {
   private Element element;
 
   public ElementHideEvent(final Element element) {

--- a/nifty-core/src/main/java/de/lessvoid/nifty/elements/events/ElementShowEvent.java
+++ b/nifty-core/src/main/java/de/lessvoid/nifty/elements/events/ElementShowEvent.java
@@ -3,7 +3,7 @@ package de.lessvoid.nifty.elements.events;
 import de.lessvoid.nifty.NiftyEvent;
 import de.lessvoid.nifty.elements.Element;
 
-public class ElementShowEvent implements NiftyEvent<Void> {
+public class ElementShowEvent implements NiftyEvent {
   private Element element;
 
   public ElementShowEvent(final Element element) {

--- a/nifty-core/src/main/java/de/lessvoid/nifty/elements/events/NiftyMouseBaseEvent.java
+++ b/nifty-core/src/main/java/de/lessvoid/nifty/elements/events/NiftyMouseBaseEvent.java
@@ -4,7 +4,7 @@ import de.lessvoid.nifty.NiftyEvent;
 import de.lessvoid.nifty.elements.Element;
 import de.lessvoid.nifty.input.NiftyMouseInputEvent;
 
-public class NiftyMouseBaseEvent implements NiftyEvent<Void> {
+public class NiftyMouseBaseEvent implements NiftyEvent {
   private Element element;
   private int mouseX;
   private int mouseY;

--- a/nifty-core/src/main/java/de/lessvoid/nifty/elements/events/NiftyMouseEvent.java
+++ b/nifty-core/src/main/java/de/lessvoid/nifty/elements/events/NiftyMouseEvent.java
@@ -4,7 +4,7 @@ import de.lessvoid.nifty.NiftyEvent;
 import de.lessvoid.nifty.elements.Element;
 import de.lessvoid.nifty.input.NiftyMouseInputEvent;
 
-public class NiftyMouseEvent implements NiftyEvent<Void> {
+public class NiftyMouseEvent implements NiftyEvent {
   private Element element;
   private int mouseX;
   private int mouseY;

--- a/nifty-core/src/main/java/de/lessvoid/nifty/elements/events/NiftyMouseMovedEvent.java
+++ b/nifty-core/src/main/java/de/lessvoid/nifty/elements/events/NiftyMouseMovedEvent.java
@@ -4,7 +4,7 @@ import de.lessvoid.nifty.NiftyEvent;
 import de.lessvoid.nifty.elements.Element;
 import de.lessvoid.nifty.input.NiftyMouseInputEvent;
 
-public class NiftyMouseMovedEvent implements NiftyEvent<Void> {
+public class NiftyMouseMovedEvent implements NiftyEvent {
   private Element element;
   private int mouseX;
   private int mouseY;

--- a/nifty-core/src/main/java/de/lessvoid/nifty/elements/events/NiftyMouseWheelEvent.java
+++ b/nifty-core/src/main/java/de/lessvoid/nifty/elements/events/NiftyMouseWheelEvent.java
@@ -4,7 +4,7 @@ import de.lessvoid.nifty.NiftyEvent;
 import de.lessvoid.nifty.elements.Element;
 import de.lessvoid.nifty.input.NiftyMouseInputEvent;
 
-public class NiftyMouseWheelEvent implements NiftyEvent<Void> {
+public class NiftyMouseWheelEvent implements NiftyEvent {
   private Element element;
   private int mouseWheel;
 

--- a/nifty-core/src/main/java/de/lessvoid/nifty/input/NiftyInputEvent.java
+++ b/nifty-core/src/main/java/de/lessvoid/nifty/input/NiftyInputEvent.java
@@ -6,7 +6,7 @@ import de.lessvoid.nifty.NiftyEvent;
  * a nifty input event.
  * @author void
  */
-public enum NiftyInputEvent implements NiftyEvent<Void> {
+public enum NiftyInputEvent implements NiftyEvent {
   /**
    * goto next input element.
    */

--- a/nifty-core/src/main/java/de/lessvoid/nifty/loaderv2/types/EffectsType.java
+++ b/nifty-core/src/main/java/de/lessvoid/nifty/loaderv2/types/EffectsType.java
@@ -1,6 +1,7 @@
 package de.lessvoid.nifty.loaderv2.types;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.LinkedList;
@@ -110,10 +111,13 @@ public class EffectsType extends XmlBaseType {
 
   public void translateSpecialValues(final Nifty nifty, final Screen screen) {
     super.translateSpecialValues(nifty, screen);
-    
-    for (Collection<EffectType> col : new Collection[]{
-        onStartScreen, onEndScreen, onHover, onStartHover, onEndHover, onClick, onFocus,
-        onLostFocus, onGetFocus, onActive, onCustom, onShow, onHide, onEnabled, onDisabled}) {
+    @SuppressWarnings ("unchecked")
+    java.util.List <Collection <EffectType>> effectTypes = Arrays.asList (
+        onStartScreen, onEndScreen,
+        onHover, onStartHover, onEndHover, onClick,
+        onFocus, onLostFocus, onGetFocus, onActive, onCustom,
+        onShow, onHide, onEnabled, onDisabled);
+    for (Collection<EffectType> col : effectTypes) {
       for (EffectType e : col) {
         e.translateSpecialValues(nifty, screen);
       }

--- a/nifty-core/src/main/java/de/lessvoid/nifty/loaderv2/types/ImageType.java
+++ b/nifty-core/src/main/java/de/lessvoid/nifty/loaderv2/types/ImageType.java
@@ -4,7 +4,7 @@ import de.lessvoid.nifty.Nifty;
 import de.lessvoid.nifty.elements.render.ElementRenderer;
 import de.lessvoid.nifty.elements.render.ImageRenderer;
 import de.lessvoid.nifty.loaderv2.types.helper.ElementRendererCreator;
-import de.lessvoid.nifty.render.NiftyImage;
+//import de.lessvoid.nifty.render.NiftyImage;
 import de.lessvoid.xml.xpp3.Attributes;
 
 public class ImageType extends ElementType {
@@ -30,7 +30,7 @@ public class ImageType extends ElementType {
     setElementRendererCreator(new ElementRendererCreator() {
       public ElementRenderer[] createElementRenderer(final Nifty nifty) {
         ElementRenderer[] renderer = new ElementRenderer[1];
-        NiftyImage niftyImage = null;
+//        NiftyImage niftyImage = null;
 //        String filename = getFilename();
 //        if (filename != null) {
 //          niftyImage = nifty.getRenderEngine().createImage(filename, false); // FIXME filter
@@ -61,7 +61,7 @@ public class ImageType extends ElementType {
 //    };
 //  }
 
-  private String getFilename() {
-    return getAttributes().get("filename");
-  }
+//  private String getFilename() {
+//    return getAttributes().get("filename");
+//  }
 }

--- a/nifty-core/src/main/java/de/lessvoid/nifty/loaderv2/types/RemoveStandardAttributes.java
+++ b/nifty-core/src/main/java/de/lessvoid/nifty/loaderv2/types/RemoveStandardAttributes.java
@@ -1,6 +1,5 @@
 package de.lessvoid.nifty.loaderv2.types;
 
-import de.lessvoid.nifty.loaderv2.types.apply.Convert;
 import de.lessvoid.xml.xpp3.Attributes;
 
 public class RemoveStandardAttributes {

--- a/nifty-core/src/main/java/de/lessvoid/nifty/loaderv2/types/TextType.java
+++ b/nifty-core/src/main/java/de/lessvoid/nifty/loaderv2/types/TextType.java
@@ -3,7 +3,6 @@ package de.lessvoid.nifty.loaderv2.types;
 import de.lessvoid.nifty.Nifty;
 import de.lessvoid.nifty.elements.render.ElementRenderer;
 import de.lessvoid.nifty.elements.render.TextRenderer;
-import de.lessvoid.nifty.loaderv2.RootLayerFactory;
 import de.lessvoid.nifty.loaderv2.types.helper.ElementRendererCreator;
 import de.lessvoid.xml.xpp3.Attributes;
 

--- a/nifty-core/src/main/java/de/lessvoid/nifty/loaderv2/types/apply/ApplyRendererImage.java
+++ b/nifty-core/src/main/java/de/lessvoid/nifty/loaderv2/types/apply/ApplyRendererImage.java
@@ -1,7 +1,5 @@
 package de.lessvoid.nifty.loaderv2.types.apply;
 
-import java.util.Properties;
-
 import de.lessvoid.nifty.Size;
 import de.lessvoid.nifty.elements.Element;
 import de.lessvoid.nifty.elements.render.ImageRenderer;

--- a/nifty-core/src/test/java/de/lessvoid/xml/lwxs/elements/ElementProcessorTest.java
+++ b/nifty-core/src/test/java/de/lessvoid/xml/lwxs/elements/ElementProcessorTest.java
@@ -1,6 +1,5 @@
 package de.lessvoid.xml.lwxs.elements;
 
-import static org.easymock.EasyMock.eq;
 import static org.easymock.EasyMock.isA;
 import static org.easymock.classextension.EasyMock.createMock;
 import static org.easymock.classextension.EasyMock.replay;
@@ -16,7 +15,6 @@ import de.lessvoid.xml.lwxs.elements.Type;
 import de.lessvoid.xml.lwxs.processor.TypeProcessorElement;
 import de.lessvoid.xml.xpp3.Attributes;
 import de.lessvoid.xml.xpp3.XmlParser;
-import de.lessvoid.xml.xpp3.XmlProcessor;
 
 public class ElementProcessorTest {
   private TypeProcessorElement elementProcessor;

--- a/nifty-core/src/test/java/de/lessvoid/xml/lwxs/elements/ElementTest.java
+++ b/nifty-core/src/test/java/de/lessvoid/xml/lwxs/elements/ElementTest.java
@@ -1,7 +1,6 @@
 package de.lessvoid.xml.lwxs.elements;
 
 import static org.easymock.EasyMock.expect;
-import static org.easymock.EasyMock.isA;
 import static org.easymock.classextension.EasyMock.createMock;
 import static org.easymock.classextension.EasyMock.replay;
 import static org.easymock.classextension.EasyMock.verify;
@@ -17,7 +16,6 @@ import de.lessvoid.xml.lwxs.Schema;
 import de.lessvoid.xml.lwxs.elements.Element;
 import de.lessvoid.xml.lwxs.elements.OccursEnum;
 import de.lessvoid.xml.lwxs.elements.Type;
-import de.lessvoid.xml.lwxs.elements.XmlProcessorElement;
 import de.lessvoid.xml.lwxs.elements.XmlProcessorType;
 
 public class ElementTest {

--- a/nifty-core/src/test/java/de/lessvoid/xml/lwxs/elements/EqCollectionMatcher.java
+++ b/nifty-core/src/test/java/de/lessvoid/xml/lwxs/elements/EqCollectionMatcher.java
@@ -7,10 +7,10 @@ import org.easymock.IArgumentMatcher;
 import org.easymock.classextension.EasyMock;
 
 public class EqCollectionMatcher implements IArgumentMatcher {
-  private Collection expectedCollection;
+  private Collection<Object> expectedCollection;
   private String errorText;
 
-  public EqCollectionMatcher(final Collection expectedCollectionParam) {
+  public EqCollectionMatcher(final Collection<Object> expectedCollectionParam) {
     expectedCollection = expectedCollectionParam;
   }
 
@@ -19,13 +19,14 @@ public class EqCollectionMatcher implements IArgumentMatcher {
       errorText = "[not an Collection instance";
       return false;
     }
-    Collection actualCollection = ((Collection) actual);
+    @SuppressWarnings ("unchecked")
+    Collection<Object> actualCollection = (Collection<Object>) actual;
     if (expectedCollection.isEmpty()) {
       errorText = "[expected collection is empty, actual is not]";
       return actualCollection.isEmpty();
     }
-    Iterator expectedIt = expectedCollection.iterator();
-    Iterator actualIt = actualCollection.iterator();
+    Iterator<Object> expectedIt = expectedCollection.iterator();
+    Iterator<Object> actualIt = actualCollection.iterator();
     while (expectedIt.hasNext()) {
       Object expectedO = expectedIt.next();
       Object actualO = actualIt.next();
@@ -41,7 +42,7 @@ public class EqCollectionMatcher implements IArgumentMatcher {
     buffer.append("mismatch dude: " + errorText);
   }
 
-  public static Collection eqCollection(final Collection in) {
+  public static Collection <Object> eqCollection(final Collection<Object> in) {
     EasyMock.reportMatcher(new EqCollectionMatcher(in));
     return null;
   }

--- a/nifty-core/src/test/java/de/lessvoid/xml/tools/SpecialValuesReplaceTest.java
+++ b/nifty-core/src/test/java/de/lessvoid/xml/tools/SpecialValuesReplaceTest.java
@@ -86,6 +86,7 @@ public class SpecialValuesReplaceTest {
   }
 
   private class MyObjectCallback {
+    @SuppressWarnings ("unused")
     public String getValue() {
       return "called";
     }

--- a/nifty-examples/src/main/java/de/lessvoid/nifty/examples/LwjglInitHelper.java
+++ b/nifty-examples/src/main/java/de/lessvoid/nifty/examples/LwjglInitHelper.java
@@ -5,7 +5,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.lwjgl.BufferUtils;
@@ -123,14 +122,15 @@ public class LwjglInitHelper {
           }
         });
 
-        for (int i = 0; i < matchingModes.length; i++) {
+        int i = 0;
+        // for (int i = 0; i < matchingModes.length; i++) {
           log.fine("using fallback mode: " + matchingModes[i].getWidth() + ", "
               + matchingModes[i].getHeight() + ", "
               + matchingModes[i].getBitsPerPixel() + ", "
               + matchingModes[i].getFrequency());
           Display.setDisplayMode(matchingModes[i]);
-          break;
-        }
+        //  break;
+        //}
       }
 
       int x = (width - Display.getDisplayMode().getWidth()) / 2;

--- a/nifty-examples/src/main/java/de/lessvoid/nifty/examples/allcontrols/AllControlsDemoStartScreen.java
+++ b/nifty-examples/src/main/java/de/lessvoid/nifty/examples/allcontrols/AllControlsDemoStartScreen.java
@@ -1,8 +1,8 @@
 package de.lessvoid.nifty.examples.allcontrols;
 
 import de.lessvoid.nifty.Nifty;
-import de.lessvoid.nifty.controls.dropdown.DropDownControl;
-import de.lessvoid.nifty.controls.listbox.ListBoxControl;
+//import de.lessvoid.nifty.controls.dropdown.DropDownControl;
+//import de.lessvoid.nifty.controls.listbox.ListBoxControl;
 import de.lessvoid.nifty.examples.NiftyExample;
 import de.lessvoid.nifty.screen.Screen;
 import de.lessvoid.nifty.screen.ScreenController;

--- a/nifty-examples/src/main/java/de/lessvoid/nifty/examples/controls/ControlsDemoStartScreen.java
+++ b/nifty-examples/src/main/java/de/lessvoid/nifty/examples/controls/ControlsDemoStartScreen.java
@@ -24,7 +24,8 @@ public class ControlsDemoStartScreen implements ScreenController, NiftyExample {
     screen = newScreen;
     nifty = newNifty;
 
-    DropDown dropDown1 = findDropDownControl("dropDown1");
+    @SuppressWarnings ("unchecked")
+    DropDown<String> dropDown1 = (DropDown<String>)findDropDownControl("dropDown1");
     if (dropDown1 != null) {
       dropDown1.addItem("Nifty GUI");
       dropDown1.addItem("Slick2d");
@@ -33,7 +34,8 @@ public class ControlsDemoStartScreen implements ScreenController, NiftyExample {
       dropDown1.selectItemByIndex(0);
     }
 
-    DropDown dropDown2 = findDropDownControl("dropDown2");
+    @SuppressWarnings ("unchecked")
+    DropDown<String> dropDown2 = (DropDown <String>)findDropDownControl("dropDown2");
     if (dropDown2 != null) {
       dropDown2.addItem("rocks!");
       dropDown2.addItem("rules!");
@@ -44,7 +46,8 @@ public class ControlsDemoStartScreen implements ScreenController, NiftyExample {
       dropDown2.selectItem("rocks!");
     }
 
-    ListBox listBoxStatic = screen.findNiftyControl("listBoxStatic", ListBox.class);
+    @SuppressWarnings ("unchecked")
+    ListBox<String> listBoxStatic = (ListBox<String>)screen.findNiftyControl("listBoxStatic", ListBox.class);
     for (int i=0; i<5; i++) {
       listBoxStatic.addItem("Listbox Item: " + i);
     }
@@ -99,7 +102,8 @@ public class ControlsDemoStartScreen implements ScreenController, NiftyExample {
 
       // create drop down
       CreateDropDownControl dynamicItem = new CreateDropDownControl("dynamicDropDown");
-      DropDown dropDown3 = dynamicItem.create(nifty, screen, row);
+      @SuppressWarnings ("unchecked")
+      DropDown<String> dropDown3 = dynamicItem.create(nifty, screen, row);
       if (dropDown3 != null) {
         dropDown3.addItem("dynamic drop down");
         dropDown3.addItem("ftw");
@@ -126,7 +130,7 @@ public class ControlsDemoStartScreen implements ScreenController, NiftyExample {
       createLabel.create(newNifty, screen, secondRow);
 
       // create a list box
-      CreateListBoxControl dynamicListboxCreate = new CreateListBoxControl("listBoxDynamic");
+      CreateListBoxControl<String> dynamicListboxCreate = new CreateListBoxControl<String>("listBoxDynamic");
       dynamicListboxCreate.set("horizontal", "false");
       dynamicListboxCreate.setWidth("*");
       dynamicListboxCreate.setHeight("100%");
@@ -134,7 +138,7 @@ public class ControlsDemoStartScreen implements ScreenController, NiftyExample {
       dynamicListboxCreate.set("horizontal", "off");
       dynamicListboxCreate.setChildLayout("vertical");
 
-      ListBox dynamicListbox = dynamicListboxCreate.create(nifty, screen, secondRow);
+      ListBox <String> dynamicListbox = dynamicListboxCreate.create(nifty, screen, secondRow);
       for (int i=0; i<10; i++) {
         dynamicListbox.addItem("Listbox Item: " + i);
       }
@@ -159,15 +163,18 @@ public class ControlsDemoStartScreen implements ScreenController, NiftyExample {
 
   public void back() {
     // this demonstrates how to access selected items
-    DropDown dropDown1 = findDropDownControl("dropDown1");
+    @SuppressWarnings ("unchecked")
+    DropDown<String> dropDown1 = (DropDown <String>)findDropDownControl("dropDown1");
     System.out.println(dropDown1.getSelection());
 
-    DropDown dropDown2 = findDropDownControl("dropDown2");
+    @SuppressWarnings ("unchecked")
+    DropDown<String> dropDown2 = (DropDown <String>)findDropDownControl("dropDown2");
     System.out.println(dropDown2.getSelection());
 
-    ListBox listBoxStatic = screen.findNiftyControl("listBoxStatic", ListBoxControl.class);
+    @SuppressWarnings ("unchecked")
+    ListBox<String> listBoxStatic = (ListBox<String>)screen.findNiftyControl("listBoxStatic", ListBoxControl.class);
     System.out.println("listBoxStatic selectedItemIndex: " + listBoxStatic.getSelection());
- 
+
     CheckBox checkBoxControl = screen.findNiftyControl("checkbox", CheckBox.class);
     System.out.println("checkbox: " + checkBoxControl.isChecked());
 
@@ -175,7 +182,7 @@ public class ControlsDemoStartScreen implements ScreenController, NiftyExample {
     nifty.fromXml("all/intro.xml", "menu");
   }
 
-  private DropDown findDropDownControl(final String id) {
+  private DropDown <?> findDropDownControl(final String id) {
     return screen.findNiftyControl(id, DropDown.class);
   }
 

--- a/nifty-examples/src/main/java/de/lessvoid/nifty/examples/defaultcontrols/ControlsDemo.java
+++ b/nifty-examples/src/main/java/de/lessvoid/nifty/examples/defaultcontrols/ControlsDemo.java
@@ -62,7 +62,7 @@ public class ControlsDemo<T> implements NiftyExample {
 
     // create Nifty and load default styles and controls
     Nifty nifty = new Nifty(new LwjglRenderDevice(true), new OpenALSoundDevice(), LwjglInitHelper.getInputSystem(), new AccurateTimeProvider());
-    ControlsDemo<DisplayMode> demo = new ControlsDemo(new ResolutionControlLWJGL());
+    ControlsDemo<DisplayMode> demo = new ControlsDemo<DisplayMode>(new ResolutionControlLWJGL());
     demo.prepareStart(nifty);
 
     nifty.gotoScreen("demo");

--- a/nifty-examples/src/main/java/de/lessvoid/nifty/examples/defaultcontrols/ControlsDemoScreenController.java
+++ b/nifty-examples/src/main/java/de/lessvoid/nifty/examples/defaultcontrols/ControlsDemoScreenController.java
@@ -234,6 +234,7 @@ public class ControlsDemoScreenController<T> implements ScreenController, KeyInp
    * @param screen
    */
   private void fillResolutionDropDown(final Screen screen) {
+    @SuppressWarnings ("unchecked")
     DropDown<T> dropDown = screen.findNiftyControl("resolutions", DropDown.class);
     final Collection<T> resolutions = resControl.getResolutions();
     for (T mode : resolutions) {

--- a/nifty-examples/src/main/java/de/lessvoid/nifty/examples/defaultcontrols/treebox/TreeboxControlDialogController.java
+++ b/nifty-examples/src/main/java/de/lessvoid/nifty/examples/defaultcontrols/treebox/TreeboxControlDialogController.java
@@ -5,7 +5,6 @@ import java.util.Properties;
 import de.lessvoid.nifty.Nifty;
 import de.lessvoid.nifty.NiftyEventSubscriber;
 import de.lessvoid.nifty.controls.Controller;
-import de.lessvoid.nifty.controls.Label;
 import de.lessvoid.nifty.controls.TextField;
 import de.lessvoid.nifty.controls.TreeBox;
 import de.lessvoid.nifty.controls.TreeItem;
@@ -19,12 +18,12 @@ import de.lessvoid.xml.xpp3.Attributes;
 /**
  * The TreeboxControlDialogController registers a new control with Nifty
  * that represents the whole Dialog. This gives us later an appropriate
- * ControlBuilder to actual construct the Dialog (as a control).
+ * ControlBuilder to actually construct the Dialog (as a control).
  * @author ractoc
  */
 public class TreeboxControlDialogController implements Controller {
 
-    private TreeBox treebox;
+    private TreeBox<String> treebox;
     private Nifty nifty;
 
     @Override
@@ -34,7 +33,9 @@ public class TreeboxControlDialogController implements Controller {
             final Element element,
             final Properties parameter,
             final Attributes controlDefinitionAttributes) {
-        this.treebox = screen.findNiftyControl("tree-box", TreeBox.class);
+        @SuppressWarnings ("unchecked")
+        TreeBox<String> t = screen.findNiftyControl("tree-box", TreeBox.class);
+        this.treebox = t;
         this.nifty = nifty;
         
         treebox.setTree(setupTree());
@@ -57,21 +58,21 @@ public class TreeboxControlDialogController implements Controller {
         return false;
     }
 
-    private TreeItem setupTree() {
+    private TreeItem<String> setupTree() {
         
         NiftyImage folder = nifty.createImage("defaultcontrols/treebox/folder.png", true);
         NiftyImage folderOpen = nifty.createImage("defaultcontrols/treebox/folder-open.png", true);
         NiftyImage item = nifty.createImage("defaultcontrols/treebox/folder.png", true);
         
-        TreeItem<String> treeRoot = new TreeItem<String>();
-        TreeItem<String> branch1 = new TreeItem<String>(treeRoot, "branch 1", "branche 1", folder, folderOpen, true);
-        TreeItem<String> branch11 = new TreeItem<String>(treeRoot, "branch 1 1", "branche 1 1", item);
-        TreeItem<String> branch12 = new TreeItem<String>(treeRoot, "branch 1 2", "branche 1 2", item);
+        TreeItem<String> treeRoot = new TreeItem <String>();
+        TreeItem<String> branch1 = new TreeItem <String>(treeRoot, "branch 1", "branche 1", folder, folderOpen, true);
+        TreeItem<String> branch11 = new TreeItem <String>(treeRoot, "branch 1 1", "branche 1 1", item);
+        TreeItem<String> branch12 = new TreeItem <String>(treeRoot, "branch 1 2", "branche 1 2", item);
         branch1.addTreeItem(branch11);
         branch1.addTreeItem(branch12);
-        TreeItem<String> branch2 = new TreeItem<String>(treeRoot, "branch 2", "branche 2", folder, folderOpen, true);
-        TreeItem<String> branch21 = new TreeItem<String>(treeRoot, "branch 2 1", "branche 2 1", folder, folderOpen, true);
-        TreeItem<String> branch211 = new TreeItem<String>(treeRoot, "branch 2 1 1", "branche 2 1 1", item);
+        TreeItem<String> branch2 = new TreeItem <String>(treeRoot, "branch 2", "branche 2", folder, folderOpen, true);
+        TreeItem<String> branch21 = new TreeItem <String>(treeRoot, "branch 2 1", "branche 2 1", folder, folderOpen, true);
+        TreeItem<String> branch211 = new TreeItem <String>(treeRoot, "branch 2 1 1", "branche 2 1 1", item);
         branch2.addTreeItem(branch21);
         branch21.addTreeItem(branch211);
         treeRoot.addTreeItem(branch1);
@@ -80,7 +81,7 @@ public class TreeboxControlDialogController implements Controller {
     }
     
     @NiftyEventSubscriber(id="tree-box")
-    public void treeItemSelected(final String id, final TreeItemSelectedEvent event) {
+    public void treeItemSelected(final String id, final TreeItemSelectedEvent<String> event) {
     	nifty.getCurrentScreen().findNiftyControl("selectedItemText", TextField.class).setText(event.getTreeItem().getDisplayCaption());
     }
 }

--- a/nifty-examples/src/main/java/de/lessvoid/nifty/examples/helloworld/HelloWorldExampleMain.java
+++ b/nifty-examples/src/main/java/de/lessvoid/nifty/examples/helloworld/HelloWorldExampleMain.java
@@ -3,7 +3,6 @@ package de.lessvoid.nifty.examples.helloworld;
 import java.io.IOException;
 
 import de.lessvoid.nifty.Nifty;
-import de.lessvoid.nifty.NiftyMouse;
 import de.lessvoid.nifty.examples.LwjglInitHelper;
 import de.lessvoid.nifty.renderer.lwjgl.render.LwjglRenderDevice;
 import de.lessvoid.nifty.sound.openal.OpenALSoundDevice;

--- a/nifty-examples/src/main/java/de/lessvoid/nifty/examples/menu/MenuStartScreen.java
+++ b/nifty-examples/src/main/java/de/lessvoid/nifty/examples/menu/MenuStartScreen.java
@@ -39,6 +39,7 @@ public class MenuStartScreen implements ScreenController, NiftyExample {
   private void createPopup() {
     this.popup = nifty.createPopup("niftyPopupMenu");
   
+    @SuppressWarnings ("unchecked")
     Menu<ThisReallyCouldBeAnyClassYouWant> popupMenu = popup.findNiftyControl("#menu", Menu.class);
   
     popupMenu.setWidth(new SizeValue("250px"));
@@ -76,9 +77,9 @@ public class MenuStartScreen implements ScreenController, NiftyExample {
     // nothing to do
   }
 
-  private class MenuItemActivatedEventSubscriber implements EventTopicSubscriber<MenuItemActivatedEvent> {
+  private class MenuItemActivatedEventSubscriber implements EventTopicSubscriber<MenuItemActivatedEvent<ThisReallyCouldBeAnyClassYouWant>> {
     @Override
-    public void onEvent(final String id, final MenuItemActivatedEvent event) {
+    public void onEvent(final String id, final MenuItemActivatedEvent<ThisReallyCouldBeAnyClassYouWant> event) {
       final ThisReallyCouldBeAnyClassYouWant item = (ThisReallyCouldBeAnyClassYouWant) event.getItem();
 
       Label label = screen.findNiftyControl("textOut", Label.class);

--- a/nifty-examples/src/main/java/de/lessvoid/nifty/examples/mouse/MouseExampleMain.java
+++ b/nifty-examples/src/main/java/de/lessvoid/nifty/examples/mouse/MouseExampleMain.java
@@ -3,7 +3,6 @@ package de.lessvoid.nifty.examples.mouse;
 import java.io.IOException;
 
 import de.lessvoid.nifty.Nifty;
-import de.lessvoid.nifty.NiftyMouse;
 import de.lessvoid.nifty.examples.LwjglInitHelper;
 import de.lessvoid.nifty.renderer.lwjgl.render.LwjglRenderDevice;
 import de.lessvoid.nifty.sound.openal.OpenALSoundDevice;

--- a/nifty-examples/src/main/java/de/lessvoid/nifty/examples/resolution/ResolutionControl.java
+++ b/nifty-examples/src/main/java/de/lessvoid/nifty/examples/resolution/ResolutionControl.java
@@ -1,7 +1,5 @@
 package de.lessvoid.nifty.examples.resolution;
 
-import org.lwjgl.LWJGLException;
-
 import java.util.Collection;
 
 /**

--- a/nifty-examples/src/main/java/de/lessvoid/nifty/examples/resolution/ResolutionScreen.java
+++ b/nifty-examples/src/main/java/de/lessvoid/nifty/examples/resolution/ResolutionScreen.java
@@ -2,11 +2,6 @@ package de.lessvoid.nifty.examples.resolution;
 
 import java.util.*;
 
-import org.lwjgl.LWJGLException;
-import org.lwjgl.opengl.Display;
-import org.lwjgl.opengl.DisplayMode;
-import org.lwjgl.opengl.GL11;
-
 import de.lessvoid.nifty.Nifty;
 import de.lessvoid.nifty.NiftyEventSubscriber;
 import de.lessvoid.nifty.controls.DropDown;

--- a/nifty-examples/src/main/java/de/lessvoid/nifty/examples/scroll/ScrollDemoStartScreen.java
+++ b/nifty-examples/src/main/java/de/lessvoid/nifty/examples/scroll/ScrollDemoStartScreen.java
@@ -9,6 +9,7 @@ import de.lessvoid.nifty.examples.NiftyExample;
 import de.lessvoid.nifty.screen.Screen;
 import de.lessvoid.nifty.screen.ScreenController;
 
+@SuppressWarnings ("deprecation")
 public class ScrollDemoStartScreen implements ScreenController, NiftyExample {
   private Nifty nifty;
   private Screen screen;

--- a/nifty-examples/src/main/java/de/lessvoid/nifty/examples/table/TableExampleMain.java
+++ b/nifty-examples/src/main/java/de/lessvoid/nifty/examples/table/TableExampleMain.java
@@ -1,29 +1,11 @@
 package de.lessvoid.nifty.examples.table;
 
 import java.io.IOException;
-import java.util.Random;
-
 import de.lessvoid.nifty.Nifty;
-import de.lessvoid.nifty.builder.ControlBuilder;
-import de.lessvoid.nifty.builder.ControlDefinitionBuilder;
-import de.lessvoid.nifty.builder.EffectBuilder;
-import de.lessvoid.nifty.builder.HoverEffectBuilder;
-import de.lessvoid.nifty.builder.LayerBuilder;
-import de.lessvoid.nifty.builder.PanelBuilder;
-import de.lessvoid.nifty.builder.ScreenBuilder;
-import de.lessvoid.nifty.builder.TextBuilder;
-import de.lessvoid.nifty.controls.ListBox;
-import de.lessvoid.nifty.controls.ListBox.ListBoxViewConverter;
-import de.lessvoid.nifty.controls.listbox.builder.ListBoxBuilder;
-import de.lessvoid.nifty.elements.Element;
-import de.lessvoid.nifty.elements.render.PanelRenderer;
-import de.lessvoid.nifty.elements.render.TextRenderer;
 import de.lessvoid.nifty.examples.LwjglInitHelper;
 import de.lessvoid.nifty.renderer.lwjgl.render.LwjglRenderDevice;
-import de.lessvoid.nifty.screen.Screen;
 import de.lessvoid.nifty.sound.openal.OpenALSoundDevice;
 import de.lessvoid.nifty.spi.time.impl.AccurateTimeProvider;
-import de.lessvoid.nifty.tools.Color;
 
 public class TableExampleMain {
 

--- a/nifty-examples/src/main/java/de/lessvoid/nifty/examples/table/TableStartScreen.java
+++ b/nifty-examples/src/main/java/de/lessvoid/nifty/examples/table/TableStartScreen.java
@@ -146,6 +146,7 @@ public class TableStartScreen implements ScreenController, NiftyExample {
     }};
     Screen startScreen = builder.build(nifty);
 
+    @SuppressWarnings ("unchecked")
     ListBox<TableRow> listBox = startScreen.findNiftyControl("serverBox", ListBox.class);
     for (int i=0; i<1000; i++) {
       listBox.addItem(new TableRow(i, randomString(), randomString(), randomString(), randomString(), randomString()));

--- a/nifty-examples/src/main/java/de/lessvoid/nifty/examples/test/ChatPanelController.java
+++ b/nifty-examples/src/main/java/de/lessvoid/nifty/examples/test/ChatPanelController.java
@@ -12,6 +12,7 @@ import de.lessvoid.nifty.screen.KeyInputHandler;
 import de.lessvoid.nifty.screen.Screen;
 import de.lessvoid.xml.xpp3.Attributes;
 
+@SuppressWarnings ("deprecation")
 public class ChatPanelController implements Controller, KeyInputHandler {
   private Nifty nifty;
   private Screen screen;

--- a/nifty-examples/src/main/java/de/lessvoid/nifty/examples/tutorial/BubblesEffect.java
+++ b/nifty-examples/src/main/java/de/lessvoid/nifty/examples/tutorial/BubblesEffect.java
@@ -8,7 +8,6 @@ import de.lessvoid.nifty.effects.EffectProperties;
 import de.lessvoid.nifty.effects.Falloff;
 import de.lessvoid.nifty.elements.Element;
 import de.lessvoid.nifty.render.NiftyImage;
-import de.lessvoid.nifty.render.NiftyImageMode;
 import de.lessvoid.nifty.render.NiftyRenderEngine;
 import de.lessvoid.nifty.spi.time.TimeProvider;
 import de.lessvoid.nifty.spi.time.impl.AccurateTimeProvider;

--- a/nifty-examples/src/main/java/de/lessvoid/nifty/examples/tutorial/SnowEffect.java
+++ b/nifty-examples/src/main/java/de/lessvoid/nifty/examples/tutorial/SnowEffect.java
@@ -13,6 +13,7 @@ import de.lessvoid.nifty.render.NiftyRenderEngine;
 import de.lessvoid.nifty.spi.time.TimeProvider;
 import de.lessvoid.nifty.spi.time.impl.AccurateTimeProvider;
 
+@Deprecated
 public class SnowEffect implements EffectImpl {
   private Snowflake[] snow = new Snowflake[256];
   private int screenWidth;

--- a/nifty-examples/src/main/java/de/lessvoid/nifty/examples/tutorial/screen/PageControl.java
+++ b/nifty-examples/src/main/java/de/lessvoid/nifty/examples/tutorial/screen/PageControl.java
@@ -29,11 +29,13 @@ public class PageControl implements Controller {
 
   @Override
   public void init(final Properties parameter, final Attributes controlDefinitionAttributes) {
+    @SuppressWarnings ("unchecked")
     DropDown<String> dropDown = screen.findNiftyControl("dropDownControl", DropDown.class);
     dropDown.addItem("a");
     dropDown.addItem("b");
     dropDown.addItem("c");
 
+    @SuppressWarnings ("unchecked")
     ListBox<String> listBox = screen.findNiftyControl("listBox", ListBox.class);
     listBox.addItem("a");
     listBox.addItem("b");

--- a/nifty-html/src/test/java/example/HtmlMain.java
+++ b/nifty-html/src/test/java/example/HtmlMain.java
@@ -64,6 +64,7 @@ public class HtmlMain implements ScreenController {
       items.add("src/test/resources/html/test-" + String.format("%02d", i) + ".html");
     }
 
+    @SuppressWarnings ("unchecked")
     DropDown<String> htmlSelectDropDown = screen.findNiftyControl("html-select", DropDown.class);
     htmlSelectDropDown.addAllItems(items);
   }

--- a/nifty-html/src/test/java/example/LwjglInitHelper.java
+++ b/nifty-html/src/test/java/example/LwjglInitHelper.java
@@ -122,14 +122,15 @@ public class LwjglInitHelper {
           }
         });
 
-        for (int i = 0; i < matchingModes.length; i++) {
+        int i = 0;
+        //for (int i = 0; i < matchingModes.length; i++) {
           log.fine("using fallback mode: " + matchingModes[i].getWidth() + ", "
               + matchingModes[i].getHeight() + ", "
               + matchingModes[i].getBitsPerPixel() + ", "
               + matchingModes[i].getFrequency());
           Display.setDisplayMode(matchingModes[i]);
-          break;
-        }
+        //  break;
+        //}
       }
 
       int x = (width - Display.getDisplayMode().getWidth()) / 2;

--- a/nifty-renderer-java2d/src/main/java/de/lessvoid/nifty/java2d/renderer/RenderDeviceJava2dImpl.java
+++ b/nifty-renderer-java2d/src/main/java/de/lessvoid/nifty/java2d/renderer/RenderDeviceJava2dImpl.java
@@ -269,19 +269,24 @@ public class RenderDeviceJava2dImpl implements RenderDevice {
 			// reference implementation or
 			// http://slick.javaunlimited.net/viewtopic.php?p=844&sid=9bfbbee23dd97e95b10ead16f9976a81
 
-			char[] charArray = text.toCharArray();
+			// NOTE: The first link is dead. The second link recommends recoloring individual pixels,
+			// which is a horrible idea; reusing the white text as an alpha channel on top of a
+			// uniformly-colored background should give Java2D a chance to hand that work to a
+			// GPU.
+
+			//char[] charArray = text.toCharArray();
 			String[] textures = angelCodeFont.getTextures();
 
 			for (int i = 0; i < text.length(); i++) {
 
 				char c = text.charAt(i);
-				char nextCharacter = i + 1 < text.length() ? text.charAt(i + 1)
-						: 0;
+				//char nextCharacter = i + 1 < text.length() ? text.charAt(i + 1)
+				//		: 0;
 
-				CharacterInfo charInfo = angelCodeFont.getChar(c);
+				de.lessvoid.nifty.java2d.renderer.fonts.CharacterInfo charInfo = angelCodeFont.getChar(c);
 
-				int kerning = 0;
-				float characterWidth = 0;
+				//int kerning = 0;
+				//float characterWidth = 0;
 
 				if (charInfo == null)
 					break;

--- a/nifty-renderer-java2d/src/main/java/de/lessvoid/nifty/java2d/renderer/RenderFontJava2dWithAngelCodeImpl.java
+++ b/nifty-renderer-java2d/src/main/java/de/lessvoid/nifty/java2d/renderer/RenderFontJava2dWithAngelCodeImpl.java
@@ -8,7 +8,7 @@ import de.lessvoid.nifty.spi.render.RenderImage;
 
 public class RenderFontJava2dWithAngelCodeImpl implements RenderFont {
 
-	private final RenderDeviceJava2dImpl renderDevice;
+	//private final RenderDeviceJava2dImpl renderDevice;
 
 	private final AngelCodeFont angelCodeFont;
 	
@@ -23,7 +23,7 @@ public class RenderFontJava2dWithAngelCodeImpl implements RenderFont {
 
 	public RenderFontJava2dWithAngelCodeImpl(
 			RenderDeviceJava2dImpl renderDevice, AngelCodeFont angelCodeFont, Map<String, RenderImage> textureImages) {
-		this.renderDevice = renderDevice;
+		//this.renderDevice = renderDevice;
 		this.angelCodeFont = angelCodeFont;
 		this.textureImages = textureImages;
 	}

--- a/nifty-renderer-java2d/src/main/java/de/lessvoid/nifty/java2d/renderer/fonts/AngelCodeFont.java
+++ b/nifty-renderer-java2d/src/main/java/de/lessvoid/nifty/java2d/renderer/fonts/AngelCodeFont.java
@@ -12,10 +12,10 @@ import java.util.Hashtable;
 import de.lessvoid.nifty.tools.resourceloader.NiftyResourceLoader;
 
 /**
- * AngelCodeFont loading.
+ * AngelCodeFont loading.<br>
+ * it is a copy from the lwjgl renderer, but it has nothing to do with the renderer, so it could be in another project.
  * 
  * @author void
- * @deprecated it is a copy from the lwjgl renderer, but it has nothing to do with the renderer, so it could be in another project.
  */
 public class AngelCodeFont {
 

--- a/nifty-renderer-java2d/src/main/java/de/lessvoid/nifty/java2d/renderer/fonts/CharacterInfo.java
+++ b/nifty-renderer-java2d/src/main/java/de/lessvoid/nifty/java2d/renderer/fonts/CharacterInfo.java
@@ -3,9 +3,10 @@ package de.lessvoid.nifty.java2d.renderer.fonts;
 import java.util.Hashtable;
 
 /**
- * info of an individual character.
+ * info of an individual character.<br>
+ * it is a copy from the lwjgl renderer, but it has nothing to do with the renderer, so it could be in another project.
+ * 
  * @author void
- * @deprecated it is a copy from the lwjgl renderer, but it has nothing to do with the renderer, so it could be in another project.
  */
 public class CharacterInfo {
   /**

--- a/nifty-renderer-jogl2/src/main/java/de/lessvoid/nifty/renderer/jogl/render/io/ImageIOImageData.java
+++ b/nifty-renderer-jogl2/src/main/java/de/lessvoid/nifty/renderer/jogl/render/io/ImageIOImageData.java
@@ -125,11 +125,11 @@ public class ImageIOImageData implements ImageData {
       if (useAlpha) {
         depth = 32;
         raster = Raster.createInterleavedRaster(DataBuffer.TYPE_BYTE, texWidth, texHeight, 4, null);
-        texImage = new BufferedImage(glAlphaColorModel, raster, false, new Hashtable());
+        texImage = new BufferedImage(glAlphaColorModel, raster, false, new Hashtable<String, Object>());
       } else {
         depth = 24;
         raster = Raster.createInterleavedRaster(DataBuffer.TYPE_BYTE, texWidth, texHeight, 3, null);
-        texImage = new BufferedImage(glColorModel, raster, false, new Hashtable());
+        texImage = new BufferedImage(glColorModel, raster, false, new Hashtable<String, Object>());
       }
       
       // copy the source image into the produced image

--- a/nifty-renderer-lwjgl/src/main/java/de/lessvoid/nifty/renderer/lwjgl/render/io/ImageIOImageData.java
+++ b/nifty-renderer-lwjgl/src/main/java/de/lessvoid/nifty/renderer/lwjgl/render/io/ImageIOImageData.java
@@ -130,11 +130,11 @@ public class ImageIOImageData implements ImageData {
     if (useAlpha) {
       depth = 32;
       raster = Raster.createInterleavedRaster(DataBuffer.TYPE_BYTE, texWidth, texHeight, 4, null);
-      texImage = new BufferedImage(glAlphaColorModel, raster, false, new Hashtable());
+      texImage = new BufferedImage(glAlphaColorModel, raster, false, new Hashtable<String, Object>());
     } else {
       depth = 24;
       raster = Raster.createInterleavedRaster(DataBuffer.TYPE_BYTE, texWidth, texHeight, 3, null);
-      texImage = new BufferedImage(glColorModel, raster, false, new Hashtable());
+      texImage = new BufferedImage(glColorModel, raster, false, new Hashtable<String, Object>());
     }
     
     // copy the source image into the produced image

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/SlickRenderDevice.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/render/SlickRenderDevice.java
@@ -20,7 +20,6 @@ import org.newdawn.slick.Graphics;
 import org.newdawn.slick.Input;
 import org.newdawn.slick.geom.Rectangle;
 import org.newdawn.slick.opengl.renderer.Renderer;
-import org.newdawn.slick.opengl.renderer.SGL;
 
 /**
  * The render device that takes care for rendering the Nifty GUI inside of Slick.

--- a/nifty-soundsystem-openal/src/main/java/de/lessvoid/nifty/sound/openal/Music.java
+++ b/nifty-soundsystem-openal/src/main/java/de/lessvoid/nifty/sound/openal/Music.java
@@ -48,7 +48,7 @@ public class Music {
 	/** True if the music is playing */
 	private boolean playing;
 	/** The list of listeners waiting for notification that the music ended */
-	private ArrayList listeners = new ArrayList();
+	private ArrayList<MusicListener> listeners = new ArrayList<MusicListener>();
 	/** The volume of this music */
 	private float volume = 1.0f;
 	/** Start gain for fading in/out */

--- a/nifty-soundsystem-openal/src/main/java/de/lessvoid/nifty/sound/openal/slick/SoundStore.java
+++ b/nifty-soundsystem-openal/src/main/java/de/lessvoid/nifty/sound/openal/slick/SoundStore.java
@@ -40,7 +40,7 @@ public class SoundStore {
 	/** The number of sound sources enabled - default 8 */
 	private int sourceCount;
 	/** The map of references to IDs of previously loaded sounds */
-	private HashMap loaded = new HashMap();
+	private HashMap<String, Integer> loaded = new HashMap<String, Integer>();
 	/** The ID of the buffer containing the music currently being played */
 	private int currentMusic = -1;
 	/** The OpenGL AL sound sources in use */
@@ -291,7 +291,7 @@ public class SoundStore {
 		log.info("Initialising sounds..");
 		inited = true;
 		
-		AccessController.doPrivileged(new PrivilegedAction() {
+		AccessController.doPrivileged(new PrivilegedAction<Object>() {
             public Object run() {
 				try {
 					AL.create();

--- a/nifty-soundsystem-pauls-sound/src/main/java/de/lessvoid/nifty/sound/paulssoundsystem/PaulsSoundsystemSoundDevice.java
+++ b/nifty-soundsystem-pauls-sound/src/main/java/de/lessvoid/nifty/sound/paulssoundsystem/PaulsSoundsystemSoundDevice.java
@@ -13,7 +13,7 @@ public class PaulsSoundsystemSoundDevice implements SoundDevice {
   private paulscode.sound.SoundSystem soundSystem;
   private int counter = 0;
 
-  public PaulsSoundsystemSoundDevice(final Class libraryClass, final SupportedCodec ... additionalCodecs) throws SoundSystemException {
+  public PaulsSoundsystemSoundDevice(final Class<?> libraryClass, final SupportedCodec ... additionalCodecs) throws SoundSystemException {
     SoundSystemConfig.setSoundFilesPackage("");
     SoundSystemConfig.addLibrary(libraryClass);
 
@@ -21,7 +21,7 @@ public class PaulsSoundsystemSoundDevice implements SoundDevice {
     SoundSystemConfig.setCodec("ogg", CodecJOrbis.class);
     SoundSystemConfig.setCodec("wav", CodecWav.class);
 
-    addAdditionalCodecs(libraryClass, additionalCodecs);
+    addAdditionalCodecs(additionalCodecs);
     soundSystem = new paulscode.sound.SoundSystem();
   }
 
@@ -29,7 +29,7 @@ public class PaulsSoundsystemSoundDevice implements SoundDevice {
   public void setResourceLoader(final NiftyResourceLoader resourceLoader) {
   }
 
-  private void addAdditionalCodecs(final Class libraryClass, final SupportedCodec... codecs) throws SoundSystemException {
+  private void addAdditionalCodecs(final SupportedCodec... codecs) throws SoundSystemException {
     if (codecs != null) {
       for (SupportedCodec codec : codecs) {
         SoundSystemConfig.setCodec(codec.getExtension(), codec.getCodecClass());

--- a/nifty-soundsystem-pauls-sound/src/main/java/de/lessvoid/nifty/sound/paulssoundsystem/SupportedCodec.java
+++ b/nifty-soundsystem-pauls-sound/src/main/java/de/lessvoid/nifty/sound/paulssoundsystem/SupportedCodec.java
@@ -2,9 +2,9 @@ package de.lessvoid.nifty.sound.paulssoundsystem;
 
 public class SupportedCodec {
   private String extension;
-  private Class codecClass;
+  private Class<?> codecClass;
 
-  public SupportedCodec(final String extension, final Class codecClass) {
+  public SupportedCodec(final String extension, final Class<?> codecClass) {
     this.extension = extension;
     this.codecClass = codecClass;
   }
@@ -13,7 +13,7 @@ public class SupportedCodec {
     return extension;
   }
 
-  public Class getCodecClass() {
+  public Class<?> getCodecClass() {
     return codecClass;
   }
 }


### PR DESCRIPTION
Warning elimination:

Removed unused imports.

Commented out unused private members and locals.
I was unsure about SpecialValuesReplaceTest.MyObjectCallback.getValue, so I
just left it in and added a @SuppressWarning.

Changed EffectsType.translateSpecialValues so that it uses Arrays.asList
instead of a generic varargs parameter (which is a combination that the Java
compiler cannot properly check for type safety).

Code simplification:

Removed gratuitous parameter on private function
PaulsSoundSystemSoundDevice.addAdditionalCodecs.

Removed the unused generic type parameter on NiftyEvent and its subclasses.
This is a compatible change, except for applications that try to Do the Right
Thing and added a <?> parameter (which can simply be removed).
Note that generic implementors of NiftyEvent have stayed generic. See
MenuItemActivatedEvent for an example.
