### PR TITLE
Only display console cursor when the textfield has focus.

### DIFF
--- a/nifty-controls-style-black/src/main/resources/console/nifty-console-style.xml
+++ b/nifty-controls-style-black/src/main/resources/console/nifty-console-style.xml
@@ -51,7 +51,7 @@
   <style id="nifty-console-textfield#cursor">
     <attributes filename="console_cursor_empty.png"/>
     <effect>
-      <onActive name="imageOverlayPulsate" period="250" timeType="infinite" pulsateType="rectangle" filename="console_cursor.png" post="true"/>
+      <onCustom name="imageOverlayPulsate" period="250" timeType="infinite" pulsateType="rectangle" filename="console_cursor.png" post="true"/>
     </effect>
   </style>
 


### PR DESCRIPTION
The console cursor is currently always displayed, even if the textfield isn't in focus. 
The solution is simple (use the same custom effect as the original textfield).
