### PR TITLE
Another one-liner

### DIFF
--- a/nifty-controls/src/main/java/de/lessvoid/nifty/controls/TreeItem.java
+++ b/nifty-controls/src/main/java/de/lessvoid/nifty/controls/TreeItem.java
@@ -123,7 +123,7 @@ public class TreeItem<T> {
         } else if (treeNodes.contains(child)) {
             return true;
         } else {
-            for (TreeItem item : treeNodes) {
+            for (TreeItem<T> item : treeNodes) {
                 boolean found = item.contains(child);
                 if (found) {
                     return true;

--- a/nifty-controls/src/main/java/de/lessvoid/nifty/controls/menu/MenuControl.java
+++ b/nifty-controls/src/main/java/de/lessvoid/nifty/controls/menu/MenuControl.java
@@ -22,7 +22,7 @@ import de.lessvoid.xml.xpp3.Attributes;
  * @deprecated Please use {@link de.lessvoid.nifty.controls.PopupMenu} when accessing NiftyControls.
  */
 @Deprecated
-public class MenuControl<T> implements NiftyControl, Controller, Menu<T> {
+public class MenuControl<T> implements Controller, Menu<T> {
   private Nifty nifty;
   private Screen screen;
   private Element element;


### PR DESCRIPTION
Overlooked remnant from last batch of updates. Sorry for the spam.
Plus a removed redundant superinterface that triggers a warning in Eclipse at standard settings.
