### PR TITLE
Textfield Bugfix and reducing of event spamming

### DIFF
--- a/nifty-core/src/main/java/de/lessvoid/nifty/elements/Element.java
+++ b/nifty-core/src/main/java/de/lessvoid/nifty/elements/Element.java
@@ -1562,7 +1562,7 @@ public class Element implements NiftyEvent<Void>, EffectManager.Notify {
     if (interaction.onMouseOver(this, mouseEvent)) {
       eatMouseEvent = true;
     }
-    if (interaction.onMouseWheel(this, mouseEvent)) {
+    if ((mouseEvent.getMouseWheel() != 0) && interaction.onMouseWheel(this, mouseEvent)) {
       eatMouseEvent = true;
     }
     return eatMouseEvent;


### PR DESCRIPTION
For the text field part I added some proper default values to the control definition, as the implicit values cause faulty behaviour.

For the event spamming: I noticed that upon mouse move events all controls that monitor mouse wheel changes are spammed with mouse wheel events containing a delta of 0 in case the mouse moves over the element. I added a test if the delta is not equal 0 in order to reduce the amount of useless calls.
