### PR TITLE
Made builders return the assigned ID on request.

### DIFF
--- a/nifty-core/src/main/java/de/lessvoid/nifty/builder/ElementBuilder.java
+++ b/nifty-core/src/main/java/de/lessvoid/nifty/builder/ElementBuilder.java
@@ -83,6 +83,14 @@ public abstract class ElementBuilder {
     attributes.setId(id);
   }
 
+  public String getId() {
+    return attributes.getId();
+  }
+
+  public boolean isAutoId() {
+    return attributes.isAutoId();
+  }
+
   public void name(final String name) {
     attributes.setName(name);
   }

--- a/nifty-core/src/main/java/de/lessvoid/nifty/controls/dynamic/attributes/ControlAttributes.java
+++ b/nifty-core/src/main/java/de/lessvoid/nifty/controls/dynamic/attributes/ControlAttributes.java
@@ -45,6 +45,10 @@ public class ControlAttributes {
     attributes.set("id", id);
   }
 
+  public String getId() {
+    return attributes.get("id");
+  }
+
   public void setAutoId(final String id) {
     isAutoId = true;
     attributes.set("id", id);


### PR DESCRIPTION
That's useful to pull out autogenerated IDs so post-construction code
can find the controls and elements via findElementByName resp.
findNiftyControl.
