### PR TITLE
Silence Maven warning about unspecified character encoding.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,11 @@
       </roles>
     </developer>
   </developers>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
   <build>
     <extensions>
       <extension>


### PR DESCRIPTION
Umlauts etc. should now properly work even when compiling on Windows.
