### PR TITLE
Decrease CPU load caused by Draggable

### DIFF
--- a/nifty-controls/src/main/java/de/lessvoid/nifty/controls/Draggable.java
+++ b/nifty-controls/src/main/java/de/lessvoid/nifty/controls/Draggable.java
@@ -2,8 +2,13 @@ package de.lessvoid.nifty.controls;
 
 /**
  * The Draggable Control interface.
+ *
  * @author void
+ * @author Martin Karing &lt;nitram@illarion.org&gt;
  */
 public interface Draggable extends NiftyControl {
-
+  /**
+   * Move the draggable control to the front inside its parent element.
+   */
+  void moveToFront();
 }

--- a/nifty-controls/src/main/java/de/lessvoid/nifty/controls/Window.java
+++ b/nifty-controls/src/main/java/de/lessvoid/nifty/controls/Window.java
@@ -21,4 +21,9 @@ public interface Window extends NiftyControl {
    * Close this Window.
    */
   void closeWindow();
+
+  /**
+   * Move the window control to the front inside its parent element.
+   */
+  void moveToFront();
 }

--- a/nifty-controls/src/main/java/de/lessvoid/nifty/controls/dragndrop/DraggableControl.java
+++ b/nifty-controls/src/main/java/de/lessvoid/nifty/controls/dragndrop/DraggableControl.java
@@ -75,9 +75,8 @@ public class DraggableControl extends AbstractController implements Draggable {
    * @param mouseY mouse y
    */
   public void bringToFront(final int mouseX, final int mouseY) {
-    originalParent = draggable.getParent();
     if (!dragged) {
-      moveDraggableOnTop();
+      moveToFront();
     }
   }
 
@@ -106,7 +105,7 @@ public class DraggableControl extends AbstractController implements Draggable {
       dragged = true;
       notifyObserversDragStarted();
     } else {
-      moveDraggableOnTop();
+      moveToFront();
     }
   }
 
@@ -166,13 +165,15 @@ public class DraggableControl extends AbstractController implements Draggable {
     });
   }
 
-  private void moveDraggableOnTop() {
-    final List<Element> siblings = originalParent.getElements();
+  @Override
+  public void moveToFront() {
+    final Element parent = draggable.getParent();
+    final List<Element> siblings = parent.getElements();
     //noinspection ObjectEquality
     if (siblings.get(siblings.size() - 1) == draggable) {
       return;
     }
-    draggable.markForMove(originalParent, new EndNotify() {
+    draggable.markForMove(parent, new EndNotify() {
       @Override
       public void perform() {
         draggable.reactivate();

--- a/nifty-controls/src/main/java/de/lessvoid/nifty/controls/window/WindowControl.java
+++ b/nifty-controls/src/main/java/de/lessvoid/nifty/controls/window/WindowControl.java
@@ -99,6 +99,11 @@ public class WindowControl extends AbstractController implements Window {
     }
   }
 
+  @Override
+  public void moveToFront() {
+    draggableControl.moveToFront();
+  }
+
   private class CloseEndNotify implements EndNotify {
     private final boolean hidden;
 

--- a/nifty-controls/src/main/java/de/lessvoid/nifty/controls/window/WindowControl.java
+++ b/nifty-controls/src/main/java/de/lessvoid/nifty/controls/window/WindowControl.java
@@ -54,8 +54,8 @@ public class WindowControl extends AbstractController implements Window {
     draggableControl.onFocus(getFocus);
   }
 
-  public void dragStart(final int mouseX, final int mouseY) {
-    draggableControl.dragStart(mouseX, mouseY);
+  public void bringToFront(final int mouseX, final int mouseY) {
+    draggableControl.bringToFront(mouseX, mouseY);
   }
 
   public void drag(final int mouseX, final int mouseY) {

--- a/nifty-controls/src/main/resources/nifty-controls/nifty-dragndrop.xml
+++ b/nifty-controls/src/main/resources/nifty-controls/nifty-dragndrop.xml
@@ -2,7 +2,7 @@
 <nifty-controls>
   <!-- DRAGGABLE CONTROL -->
   <controlDefinition name="draggable" childRootId="#draggableContent" controller="de.lessvoid.nifty.controls.dragndrop.DraggableControl">
-    <interact onClick="dragStart()" onClickMouseMove="drag()" onRelease="dragStop()" />
+    <interact onClick="bringToFront()" onClickMouseMove="drag()" onRelease="dragStop()" />
     <panel id="#draggableContent"/>
   </controlDefinition>
 

--- a/nifty-controls/src/main/resources/nifty-controls/nifty-window.xml
+++ b/nifty-controls/src/main/resources/nifty-controls/nifty-window.xml
@@ -2,7 +2,7 @@
 <nifty-controls>
   <!-- WINDOW CONTROL -->
   <controlDefinition name="window" style="nifty-window" childRootId="#window-content" controller="de.lessvoid.nifty.controls.window.WindowControl" revert="false" drop="false" handle="#window-bar">
-    <interact onClick="dragStart()" onClickMouseMove="drag()" onRelease="dragStop()" />
+    <interact onClick="bringToFront()" onClickMouseMove="drag()" onRelease="dragStop()" />
     <panel style="#frame">
       <panel id="#window-bar" style="#bar">
         <text id="#window-title" style="#title" text="$title" />


### PR DESCRIPTION
The draggable control now only triggers dragging in case there is really a drag action. In case just a click is done the control just pulls the draggable to the front if its not in the front already.
