### PR TITLE
JOGLNiftyRunner: use canvas preferred size to set frame insets.

### DIFF
--- a/nifty-examples-jogl/src/main/java/de/lessvoid/nifty/examples/jogl/JOGLNiftyRunner.java
+++ b/nifty-examples-jogl/src/main/java/de/lessvoid/nifty/examples/jogl/JOGLNiftyRunner.java
@@ -1,6 +1,7 @@
 package de.lessvoid.nifty.examples.jogl;
 
 import java.awt.Frame;
+import java.awt.Dimension;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.io.InputStream;
@@ -68,14 +69,14 @@ public class JOGLNiftyRunner implements GLEventListener {
 
     canvas = new GLCanvas(new GLCapabilities(getProfile(useBatchedCoreRenderer)));
     canvas.setAutoSwapBufferMode(true);
-    canvas.setSize(CANVAS_WIDTH, CANVAS_HEIGHT);
+    canvas.setPreferredSize(new Dimension(CANVAS_WIDTH, CANVAS_HEIGHT));
     canvas.addGLEventListener(new JOGLNiftyRunner(callback));
 
     final FPSAnimator animator = new FPSAnimator(canvas, FPS, false);
 
     frame = new Frame(getCaption(useBatchedRenderer, useBatchedCoreRenderer));
-    frame.setSize(CANVAS_WIDTH, CANVAS_HEIGHT);
     frame.add(canvas);
+    frame.pack();
     frame.setVisible(true);
     frame.addWindowListener(new WindowAdapter() {
       public void windowClosing(WindowEvent e) {

--- a/nifty-examples-jogl/src/main/java/de/lessvoid/nifty/examples/jogl/ResolutionControlJOGL.java
+++ b/nifty-examples-jogl/src/main/java/de/lessvoid/nifty/examples/jogl/ResolutionControlJOGL.java
@@ -1,6 +1,7 @@
 package de.lessvoid.nifty.examples.jogl;
 
 import java.awt.Frame;
+import java.awt.Dimension;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -55,8 +56,8 @@ public class ResolutionControlJOGL implements ResolutionControl<Resolution> {
     }
 
     public void apply(final Frame frame, final GLCanvas canvas) {
-      frame.setSize(width, height);
-      canvas.setSize(width, height);
+      canvas.setPreferredSize(new Dimension(width, height));
+      frame.pack();
 
       GL gl = canvas.getGL();
       gl.glViewport(0, 0, width, height);


### PR DESCRIPTION
ResolutionControlJOGL: likewise.

Signed-off-by: Xerxes Rånby xerxes@zafena.se
