### PR TITLE
Added missing init call in scroll panel

### DIFF
--- a/nifty-controls/src/main/java/de/lessvoid/nifty/controls/scrollpanel/ScrollPanelControl.java
+++ b/nifty-controls/src/main/java/de/lessvoid/nifty/controls/scrollpanel/ScrollPanelControl.java
@@ -62,6 +62,7 @@ public class ScrollPanelControl extends AbstractController implements ScrollPane
     initializeScrollbars();
     subscribeHorizontalScrollbar();
     subscribeVerticalScrollbar();
+    super.init(parameter);
   }
 
   @Override


### PR DESCRIPTION
The missing init call rendered the scroll panel unusable. This error
was introduced during the API change of the init function.
