### PR TITLE
Increased visibility of mouse related nifty-renderer-slick input events

### DIFF
--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/input/events/AbstractMouseEvent.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/input/events/AbstractMouseEvent.java
@@ -45,7 +45,7 @@ public abstract class AbstractMouseEvent implements InputEvent {
    *
    * @return the x coordinate of the event location
    */
-  protected final int getX() {
+  public final int getX() {
     return locX;
   }
 
@@ -54,7 +54,7 @@ public abstract class AbstractMouseEvent implements InputEvent {
    *
    * @return the y coordinate of the event location
    */
-  protected final int getY() {
+  public final int getY() {
     return locY;
   }
 

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/input/events/AbstractMouseEventButton.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/input/events/AbstractMouseEventButton.java
@@ -29,7 +29,7 @@ public abstract class AbstractMouseEventButton extends AbstractMouseEvent {
    *
    * @return the button ID
    */
-  protected final int getButton() {
+  public final int getButton() {
     return button;
   }
 }

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/input/events/MouseEventClicked.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/input/events/MouseEventClicked.java
@@ -57,4 +57,14 @@ public final class MouseEventClicked extends AbstractMouseEventButton {
     listener.mouseClicked(getButton(), getX(), getY(), count);
     return true;
   }
+
+  /**
+   * Get the count of how often the button got clicked.
+   *
+   * @return the mouse button click count
+   */
+  public final int getCount() {
+    return count;
+  }
+
 }

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/input/events/MouseEventDragged.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/input/events/MouseEventDragged.java
@@ -53,4 +53,22 @@ public final class MouseEventDragged extends AbstractMouseEventButton {
     return true;
   }
 
+  /**
+   * Get the X coordinate where the movement stopped.
+   *
+   * @return the final mouse X coordinate
+   */
+  public final int getTargetX() {
+    return targetX;
+  }
+
+  /**
+   * Get the Y coordinate where the movement stopped.
+   *
+   * @return the final mouse Y coordinate
+   */
+  public final int getTargetY() {
+    return targetY;
+  }
+
 }

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/input/events/MouseEventMoved.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/input/events/MouseEventMoved.java
@@ -52,4 +52,22 @@ public final class MouseEventMoved extends AbstractMouseEvent {
     return false;
   }
 
+  /**
+   * Get the X coordinate where the movement stopped.
+   *
+   * @return the final mouse X coordinate
+   */
+  public final int getTargetX() {
+    return targetX;
+  }
+
+  /**
+   * Get the Y coordinate where the movement stopped.
+   *
+   * @return the final mouse Y coordinate
+   */
+  public final int getTargetY() {
+    return targetY;
+  }
+
 }

--- a/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/input/events/MouseEventWheelMoved.java
+++ b/nifty-renderer-slick/src/main/java/de/lessvoid/nifty/slick2d/input/events/MouseEventWheelMoved.java
@@ -45,4 +45,13 @@ public final class MouseEventWheelMoved extends AbstractMouseEvent {
     return true;
   }
 
+  /**
+   * Get the delta value that defines how much and into what direction the mouse wheel got moved.
+   *
+   * @return the mouse wheel delta value
+   */
+  public final int getDelta() {
+    return wheelDelta;
+  }
+
 }


### PR DESCRIPTION
Hi

I am writing an alternative system to handle the `InputEvent`'s generated from Nifty/Slick2d, and found that the mouse related events have fields that are not visible from the outside. This makes it impossible to create a custom `AbstractSlickInputSystem`, as you cannot access the information contained in each event.

Would it be possible to increase the visibility of these fields (and add getters where necessary) ? 

Simon
