### PR TITLE
Automatic style reloading

### DIFF
--- a/nifty-core/src/main/java/de/lessvoid/nifty/loaderv2/NiftyLoader.java
+++ b/nifty-core/src/main/java/de/lessvoid/nifty/loaderv2/NiftyLoader.java
@@ -181,7 +181,7 @@ public class NiftyLoader {
       closeSilently(stream);
     }
   }
-
+  
   public void loadControlFile(
       @Nonnull final String schemaId,
       @Nonnull final String controlFilename,


### PR DESCRIPTION
Hello,
This changes was made to let the user edit their style and see the changes in the nifty-editor. So I don't know if this feature will ever use by standar nifty-gui user, but It's needed to have a nice real-time editing of a gui. 

In practice I added a check in reloadstyle method to see if the style id was already registered in nifty. If it so nifty will publish the event on the eventbus. In this way the elements subscribed with that syle id will reload its style and display the changes. In my opinion this PR won't effect a normal use of library , plus in this way the user will warned if he is registering a style twice.

Unfortunately this automatic system won't work on control due to #287.
