### PR TITLE
Implementation of JoglMouseCursor

### DIFF
--- a/nifty-controls/src/main/java/de/lessvoid/nifty/controls/chatcontrol/ChatBoxViewConverter.java
+++ b/nifty-controls/src/main/java/de/lessvoid/nifty/controls/chatcontrol/ChatBoxViewConverter.java
@@ -1,12 +1,13 @@
 package de.lessvoid.nifty.controls.chatcontrol;
 
+import java.util.logging.Logger;
+
+import javax.annotation.Nonnull;
+
 import de.lessvoid.nifty.controls.ListBox.ListBoxViewConverter;
 import de.lessvoid.nifty.elements.Element;
 import de.lessvoid.nifty.elements.render.ImageRenderer;
 import de.lessvoid.nifty.elements.render.TextRenderer;
-
-import javax.annotation.Nonnull;
-import java.util.logging.Logger;
 
 /**
  * Handles the displaying of the items in the ChatBox.
@@ -50,13 +51,14 @@ public class ChatBoxViewConverter implements ListBoxViewConverter<ChatEntryModel
       log.severe("Icon entry of the chat line does not contain the required image renderer.");
       return;
     }
-    textRenderer.setText(item.toString());
-    iconRenderer.setImage(item.getIcon());
     if (item.getStyle() != null && !item.getStyle().equals("")) {
       text.setStyle(item.getStyle());
     } else {
       text.setStyle("default");
     }
+    // setStyle will reset the text to initial value (null), so setText/setImage should be called after it
+    textRenderer.setText(item.toString());
+    iconRenderer.setImage(item.getIcon());
   }
 
   @Override

--- a/nifty-examples-jogl/src/main/java/de/lessvoid/nifty/examples/jogl/JOGLNiftyRunner.java
+++ b/nifty-examples-jogl/src/main/java/de/lessvoid/nifty/examples/jogl/JOGLNiftyRunner.java
@@ -5,12 +5,7 @@ import java.util.logging.LogManager;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import javax.media.opengl.GL;
-import javax.media.opengl.GL2;
-import javax.media.opengl.GLAutoDrawable;
-import javax.media.opengl.GLCapabilities;
-import javax.media.opengl.GLEventListener;
-import javax.media.opengl.GLProfile;
+import javax.media.opengl.*;
 
 import paulscode.sound.SoundSystemException;
 import paulscode.sound.libraries.LibraryJavaSound;
@@ -123,11 +118,11 @@ public class JOGLNiftyRunner implements GLEventListener {
   public void init(GLAutoDrawable drawable) {
     RenderDevice renderDevice;
     if (Mode.Batch.equals(mode)) {
-      renderDevice = new BatchRenderDevice(JoglBatchRenderBackendFactory.create());
+      renderDevice = new BatchRenderDevice(JoglBatchRenderBackendFactory.create(window));
     } else if (Mode.Core.equals(mode)) {
-      renderDevice = new BatchRenderDevice(JoglBatchRenderBackendCoreProfileFactory.create());
+      renderDevice = new BatchRenderDevice(JoglBatchRenderBackendCoreProfileFactory.create(window));
     } else if (Mode.ES2.equals(mode)) {
-      renderDevice = new BatchRenderDevice(JoglBatchRenderBackendCoreProfileFactory.create());
+      renderDevice = new BatchRenderDevice(JoglBatchRenderBackendCoreProfileFactory.create(window));
     } else {
       renderDevice = new JoglRenderDevice();
     }

--- a/nifty-renderer-jogl/src/main/java/de/lessvoid/nifty/renderer/jogl/render/JoglBatchRenderBackendCoreProfileFactory.java
+++ b/nifty-renderer-jogl/src/main/java/de/lessvoid/nifty/renderer/jogl/render/JoglBatchRenderBackendCoreProfileFactory.java
@@ -1,21 +1,24 @@
 package de.lessvoid.nifty.renderer.jogl.render;
 
+import javax.annotation.Nonnull;
+
+import com.jogamp.newt.Window;
+
 import de.lessvoid.nifty.render.batch.core.BatchRenderBackendCoreProfileInternal;
 import de.lessvoid.nifty.render.batch.spi.BatchRenderBackend;
-
-import javax.annotation.Nonnull;
 
 /**
  * @author Aaron Mahan &lt;aaron@forerunnergames.com&gt;
  */
 public class JoglBatchRenderBackendCoreProfileFactory {
+	
   @Nonnull
-  public static BatchRenderBackend create() {
+  public static BatchRenderBackend create(Window newtWindow) {
     return new BatchRenderBackendCoreProfileInternal(
             new JoglCoreGL(),
             new JoglBufferFactory(),
             new JoglImageFactory(),
-            new JoglMouseCursorFactory());
+            new JoglMouseCursorFactory(newtWindow));
   }
 }
 

--- a/nifty-renderer-jogl/src/main/java/de/lessvoid/nifty/renderer/jogl/render/JoglBatchRenderBackendFactory.java
+++ b/nifty-renderer-jogl/src/main/java/de/lessvoid/nifty/renderer/jogl/render/JoglBatchRenderBackendFactory.java
@@ -1,24 +1,22 @@
 package de.lessvoid.nifty.renderer.jogl.render;
 
+import javax.annotation.Nonnull;
+
+import com.jogamp.newt.Window;
+
 import de.lessvoid.nifty.render.batch.BatchRenderBackendInternal;
 import de.lessvoid.nifty.render.batch.spi.BatchRenderBackend;
-import de.lessvoid.nifty.renderer.jogl.render.JoglBufferFactory;
-import de.lessvoid.nifty.renderer.jogl.render.JoglGL;
-import de.lessvoid.nifty.renderer.jogl.render.JoglImageFactory;
-import de.lessvoid.nifty.renderer.jogl.render.JoglMouseCursorFactory;
-
-import javax.annotation.Nonnull;
 
 /**
  * @author Aaron Mahan &lt;aaron@forerunnergames.com&gt;
  */
 public class JoglBatchRenderBackendFactory {
   @Nonnull
-  public static BatchRenderBackend create() {
+  public static BatchRenderBackend create(Window newtWindow) {
     return  new BatchRenderBackendInternal(
             new JoglGL(),
             new JoglBufferFactory(),
             new JoglImageFactory(),
-            new JoglMouseCursorFactory());
+            new JoglMouseCursorFactory(newtWindow));
   }
 }

--- a/nifty-renderer-jogl/src/main/java/de/lessvoid/nifty/renderer/jogl/render/JoglMouseCursor.java
+++ b/nifty-renderer-jogl/src/main/java/de/lessvoid/nifty/renderer/jogl/render/JoglMouseCursor.java
@@ -49,8 +49,8 @@ public class JoglMouseCursor implements MouseCursor {
 			
 			// grab pixel data from BufferedImage
 			int[] pixels = new int[image.getWidth() * image.getHeight()];
-			final IntBuffer pixelIntBuff = Buffers.newDirectIntBuffer(image.getData().getPixels(0, 0, 
-					image.getWidth(), image.getHeight(), pixels));
+			image.getRGB(0, 0, image.getWidth(), image.getHeight(), pixels, 0, image.getWidth());
+			final IntBuffer pixelIntBuff = Buffers.newDirectIntBuffer(pixels);
 			final ByteBuffer pixelBuff = Buffers.copyIntBufferAsByteBuffer(pixelIntBuff);
 			
 			// find compatible PixelFormat
@@ -67,7 +67,7 @@ public class JoglMouseCursor implements MouseCursor {
 					pixelBuff);
 			joglCursor = newtWindow.getScreen().getDisplay().createPointerIcon(rec, hotspotX, hotspotY);
 		} catch (Exception e) {
-			throw new IOException(e);
+			throw(new RuntimeException(e));
 		} finally {
 			try {
 				imageStream.close();

--- a/nifty-renderer-jogl/src/main/java/de/lessvoid/nifty/renderer/jogl/render/JoglMouseCursorFactory.java
+++ b/nifty-renderer-jogl/src/main/java/de/lessvoid/nifty/renderer/jogl/render/JoglMouseCursorFactory.java
@@ -1,17 +1,27 @@
 package de.lessvoid.nifty.renderer.jogl.render;
 
+import java.io.IOException;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import com.jogamp.newt.Window;
+
 import de.lessvoid.nifty.render.batch.spi.MouseCursorFactory;
 import de.lessvoid.nifty.spi.render.MouseCursor;
 import de.lessvoid.nifty.tools.resourceloader.NiftyResourceLoader;
-
-import java.io.IOException;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
 /**
  * @author Aaron Mahan &lt;aaron@forerunnergames.com&gt;
  */
 public class JoglMouseCursorFactory implements MouseCursorFactory {
+	
+	private final Window newtWindow;
+	
+	public JoglMouseCursorFactory(@Nonnull final Window newtWindow) {
+		this.newtWindow = newtWindow;
+	}
+	
   @Nullable
   @Override
   public MouseCursor create(
@@ -19,6 +29,6 @@ public class JoglMouseCursorFactory implements MouseCursorFactory {
           int hotspotX,
           int hotspotY,
           @Nonnull NiftyResourceLoader resourceLoader) throws IOException {
-    return new JoglMouseCursor(filename, hotspotX, hotspotY, resourceLoader);
+    return new JoglMouseCursor(filename, hotspotX, hotspotY, newtWindow, resourceLoader);
   }
 }

--- a/nifty-renderer-jogl/src/main/java/de/lessvoid/nifty/renderer/jogl/render/JoglRenderDevice.java
+++ b/nifty-renderer-jogl/src/main/java/de/lessvoid/nifty/renderer/jogl/render/JoglRenderDevice.java
@@ -13,6 +13,7 @@ import javax.media.opengl.GL2;
 import javax.media.opengl.GLContext;
 
 import com.jogamp.common.nio.Buffers;
+import com.jogamp.newt.Window;
 
 import de.lessvoid.nifty.render.BlendMode;
 import de.lessvoid.nifty.spi.render.MouseCursor;
@@ -36,6 +37,8 @@ public class JoglRenderDevice implements RenderDevice {
   private static final IntBuffer viewportBuffer = Buffers.newDirectIntBuffer(4);
   @Nonnull
   private final TimeProvider timeProvider = new AccurateTimeProvider();
+  @Nullable // for now
+  private Window newtWindow;
   @Nullable
   private RenderFont fpsFont;
   @Nullable
@@ -57,24 +60,48 @@ public class JoglRenderDevice implements RenderDevice {
   private int currentClippingX1 = 0;
   private int currentClippingY1 = 0;
 
+  @Deprecated
+  /**
+   * @deprecated Replaced by {@link #JoglRenderDevice(com.jogamp.newt.Window)}
+   * Use of this constructor will cause some RenderDevice operations to fail.
+   */
+  public JoglRenderDevice() {
+  	this(null);
+  }
+
+  @Deprecated
+  /**
+   * @deprecated Replaced by {@link #JoglRenderDevice(com.jogamp.newt.Window,boolean)}
+   * Use of this constructor will cause some RenderDevice operations to fail.
+   * @param displayFPS display the FPS counter on the screen
+   */
+  public JoglRenderDevice(final boolean displayFPS) {
+  	this(null, displayFPS);
+  }
+  
   /**
    * The standard constructor. You'll use this in production code. Using this constructor will
    * configure the RenderDevice to not log FPS on System.out.
+   * @param newtWindow the current window handling the rendering context
    */
-  public JoglRenderDevice() {
+  public JoglRenderDevice(final Window newtWindow) {
+  	if(newtWindow == null)
+  		log.warning("newtWindow parameter is null - some RenderDevice operations may not work properly");
+  	this.newtWindow = newtWindow;
     time = timeProvider.getMsTime();
     frames = 0;
   }
-
+  
   /**
    * The development mode constructor allows to display the FPS on screen when the given flag is
    * set to true. Note that setting displayFPS to false will still log the FPS on System.out every
    * couple of frames.
    *
+   * @param newtWindow the current window handling the rendering context
    * @param displayFPS display the FPS counter on the screen
    */
-  public JoglRenderDevice(final boolean displayFPS) {
-    this();
+  public JoglRenderDevice(final Window newtWindow, final boolean displayFPS) {
+  	this(newtWindow);
     this.logFPS = true;
     this.displayFPS = displayFPS;
     if (this.displayFPS) {
@@ -433,7 +460,7 @@ public class JoglRenderDevice implements RenderDevice {
 
   @Override
   public MouseCursor createMouseCursor(@Nonnull String filename, int hotspotX, int hotspotY) throws IOException {
-    return new JoglMouseCursor(filename, hotspotX, hotspotY, resourceLoader);
+    return new JoglMouseCursor(filename, hotspotX, hotspotY, newtWindow, resourceLoader);
   }
 
   @Override


### PR DESCRIPTION
-JoglMouseCursor no longer uses AWT references and should (hopefully) be working properly
-JoglRenderDevice now requires a com.jogamp.newt.Window parameter in the constructor (old constructors are deprecated with warnings).
-JoglMouseCursorFactory now requires a com.jogamp.newt.Window parameter in order to create JoglMouseCursor
-JoglBatchRenderBackendFactory/JoglBatchRenderBackendCoreProfileFactory now require a com.jogamp.newt.Window parameter in their 'create' methods in order to initialize JoglMouseCursorFactory

I would appreciate it if someone with better knowledge of Nifty setup (and using the Nifty MouseCursor API) than I could test this to see if it is working properly before merging. Thanks!

PR resolves #206 
