### PR TITLE
fix: #341 Correcting Hint Effect layer not activating / deactivating

### DIFF
--- a/nifty-core/src/main/java/de/lessvoid/nifty/effects/Effect.java
+++ b/nifty-core/src/main/java/de/lessvoid/nifty/effects/Effect.java
@@ -95,15 +95,13 @@ public class Effect {
     controllerArray = controllers.toArray();
     effectEvents.init(nifty, controllerArray, parameter);
     customFlag = false;
-
-    if (hoverEffect) {
-      element.setVisibleToMouseEvents(true);
-    }
   }
 
   public void enableHover(final Falloff falloffParameter) {
     hoverEffect = true;
     falloff = falloffParameter;
+
+    element.setVisibleToMouseEvents(true);
   }
 
   public void disableHover() {

--- a/nifty-core/src/main/java/de/lessvoid/nifty/effects/impl/Hint.java
+++ b/nifty-core/src/main/java/de/lessvoid/nifty/effects/impl/Hint.java
@@ -152,7 +152,7 @@ public class Hint implements EffectImpl {
       hintPanel.markForRemoval(new EndNotify() {
         @Override
         public void perform() {
-          if (hintLayer.getChildrenCount() == 1) {
+          if (hintLayer.getChildrenCount() <= 1) {
             hintLayer.hide();
           }
         }

--- a/nifty-core/src/test/java/de/lessvoid/nifty/effects/HoverEffectTest.java
+++ b/nifty-core/src/test/java/de/lessvoid/nifty/effects/HoverEffectTest.java
@@ -1,0 +1,57 @@
+package de.lessvoid.nifty.effects;
+
+import de.lessvoid.nifty.Nifty;
+import de.lessvoid.nifty.effects.impl.Nop;
+import de.lessvoid.nifty.elements.Element;
+import de.lessvoid.nifty.spi.time.impl.AccurateTimeProvider;
+import org.easymock.EasyMock;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.LinkedList;
+import java.util.Properties;
+
+import static org.easymock.EasyMock.expectLastCall;
+import static org.easymock.EasyMock.replay;
+
+public class HoverEffectTest {
+
+  private static final boolean INHERIT_FALSE = false;
+  private static final boolean POST_FALSE = false;
+  private static final boolean OVERLAY_TRUE = true;
+  private static final String ALTERNATE_ENABLE_NULL = null;
+  private static final String ALTERNATE_DISABLE_NULL = null;
+  private static final String CUSTOM_KEY_NULL = null;
+  private static final boolean NEVER_STOP_RENDERING = false;
+
+  Nifty nifty = EasyMock.createMock(Nifty.class);
+  Element element = EasyMock.createMock(Element.class);
+  Effect effect;
+
+  @Before
+  public void setUp() {
+    effect = new Effect(
+        nifty,
+        INHERIT_FALSE,
+        POST_FALSE,
+        OVERLAY_TRUE,
+        ALTERNATE_ENABLE_NULL,
+        ALTERNATE_DISABLE_NULL,
+        CUSTOM_KEY_NULL,
+        NEVER_STOP_RENDERING,
+        EffectEventId.onActive,
+        element,
+        new Nop(),
+        new EffectProperties(new Properties()), new AccurateTimeProvider(),
+        new LinkedList<Object>());
+  }
+
+  @Test
+  public void shouldSetVisibleToMouseEventsOnElementWhenHoverEnabled() {
+    element.setVisibleToMouseEvents(true);
+    expectLastCall();
+    replay(element);
+
+    effect.enableHover(new Falloff(new Properties()));
+  }
+}


### PR DESCRIPTION
In Effect, the hoverEffect boolean was being checked as a prerequisite to enabling visibleToMouseEvents. During the refactor in bd08f8ce208a2b8e626d1e5f467beb016ac93360 this check was moved. It now happens before anything that can set hoverEffect to true, and in effect evaluates to always false.

This change drops the if check entirely and moves enabling the visibileToMouseEvents flag to Effect#enableHover(). Not sure if that's where you want it, but it seems reasonable.
# 

This also corrects a check in the Hint effect itself. When the Hint effect deactivates, it checks if there is exactly one child, and if so, hides the hint panel. I do not know the cause of this one, but there were zero children at this check. (I assume some other code changed that cleaned up the children).

This was changed to check if there is one or less children as a condition to hiding the hint layer.
# 

Normally I'd like to put these fixes up separately, but since I went in to fix the hint layer because of the first bug, and then discovered the second one, I'd rather commit it together and put the hint layer back into a working state.
# 

It is worth noting that if a hover effect is removed from the element, I think the visibleToMouseEvents flag will remain set. That might be a separate issue where we apply a check to see if visibleToMouseEvents was set exclusively because of adding a hover effect. Uncertain if this is required though.
