### PR TITLE
feat: system property setting for default NiftyInputMapping.

### DIFF
--- a/nifty-core/src/main/java/de/lessvoid/nifty/Nifty.java
+++ b/nifty-core/src/main/java/de/lessvoid/nifty/Nifty.java
@@ -36,6 +36,7 @@ import de.lessvoid.nifty.elements.Element;
 import de.lessvoid.nifty.elements.ElementMoveAction;
 import de.lessvoid.nifty.elements.ElementRemoveAction;
 import de.lessvoid.nifty.elements.EndOfFrameElementAction;
+import de.lessvoid.nifty.input.NiftyInputMapping;
 import de.lessvoid.nifty.input.NiftyMouseInputEvent;
 import de.lessvoid.nifty.input.keyboard.KeyboardInputEvent;
 import de.lessvoid.nifty.input.mouse.MouseInputEventProcessor;
@@ -2099,5 +2100,14 @@ public class Nifty {
 
   public boolean isNiftyMethodInvokerDebugEnabled() {
     return niftyMethodInvokerDebugEnabled;
+  }
+
+  /**
+   * Sets the static default NiftyInputMapping used by all input event handlers.
+   * <b>Important note: this change will persist to all Nifty instances.</b>
+   */
+  public static void setDefaultInputMappingType (@Nonnull final Class<? extends NiftyInputMapping> defaultInputMappingType)
+  {
+    NiftyDefaults.setDefaultInputMapping(defaultInputMappingType);
   }
 }

--- a/nifty-core/src/main/java/de/lessvoid/nifty/NiftyDefaults.java
+++ b/nifty-core/src/main/java/de/lessvoid/nifty/NiftyDefaults.java
@@ -1,10 +1,15 @@
 package de.lessvoid.nifty;
 
-import de.lessvoid.nifty.loaderv2.types.RegisterEffectType;
-
 import javax.annotation.Nonnull;
 
+import de.lessvoid.nifty.input.NiftyInputMapping;
+import de.lessvoid.nifty.input.mapping.DefaultInputMapping;
+import de.lessvoid.nifty.loaderv2.types.RegisterEffectType;
+import de.lessvoid.xml.tools.ClassHelper;
+
 public class NiftyDefaults {
+  private static Class <? extends NiftyInputMapping> defaultNiftyInputMapping = DefaultInputMapping.class;
+
   private NiftyDefaults() {
   }
 
@@ -50,6 +55,20 @@ public class NiftyDefaults {
     nifty.registerEffect(new RegisterEffectType("textColorAnimated", "de.lessvoid.nifty.effects.impl.TextColorAnimated"));
     nifty.registerEffect(new RegisterEffectType("textSize", "de.lessvoid.nifty.effects.impl.TextSize"));
     nifty.registerEffect(new RegisterEffectType("textSizePulsate", "de.lessvoid.nifty.effects.impl.TextSizePulsate"));
-    nifty.registerEffect(new RegisterEffectType("updateScrollpanelPositionToDisplayElement", "de.lessvoid.nifty.controls.scrollbar.UpdateScrollpanelPositionToDisplayElement"));    
+    nifty.registerEffect(new RegisterEffectType("updateScrollpanelPositionToDisplayElement", "de.lessvoid.nifty.controls.scrollbar.UpdateScrollpanelPositionToDisplayElement"));
+  }
+
+  @Nonnull
+  public static NiftyInputMapping getDefaultInputMapping() {
+    return ClassHelper.getInstance(defaultNiftyInputMapping);
+  }
+
+  static void setDefaultInputMapping(final Class<? extends NiftyInputMapping> defaultInputMappingType)
+  {
+    if (defaultInputMappingType == null)
+    {
+      return;
+    }
+    defaultNiftyInputMapping = defaultInputMappingType;
   }
 }

--- a/nifty-core/src/main/java/de/lessvoid/nifty/loaderv2/types/ElementType.java
+++ b/nifty-core/src/main/java/de/lessvoid/nifty/loaderv2/types/ElementType.java
@@ -1,6 +1,7 @@
 package de.lessvoid.nifty.loaderv2.types;
 
 import de.lessvoid.nifty.Nifty;
+import de.lessvoid.nifty.NiftyDefaults;
 import de.lessvoid.nifty.controls.Controller;
 import de.lessvoid.nifty.controls.NiftyInputControl;
 import de.lessvoid.nifty.controls.dynamic.attributes.ControlAttributes;
@@ -240,7 +241,7 @@ public class ElementType extends XmlBaseType {
       inputMapping = ClassHelper.getInstance(inputMappingClass, NiftyInputMapping.class);
     }
     if (inputMapping == null) {
-      inputMapping = new DefaultInputMapping();
+      inputMapping = NiftyDefaults.getDefaultInputMapping();
     }
 
     return new NiftyInputControl(controller, inputMapping);


### PR DESCRIPTION
<<< PLEASE TEST THIS! >>>

ElementType will now use a default class type accessed by name via a system property specified by NiftyDefaults.

Unfortunately, there is no way to inject the setting into ElementType at this time due to no instance of Nifty (or Screen, ScreenController, etc) being accessible. This is a "maximum compatibility" approach, but it should be noted that it is most certainly non-optimal. Using system properties is kind of gross...

Regardless, this should allow users to override Nifty's default input mapper, so that mappings can be applied globally.

Note: the danger here is that the setting will persist throughout the JVM rather than just a single Nifty or Screen instance. Again, not optimal.

Resolves #348 
