### PR TITLE
The events should not be sent to Slick InputListener if the listener is not accepting the input.

### DIFF
--- a/nifty-renderer-slick2d/src/main/java/de/lessvoid/nifty/slick2d/input/events/KeyboardEventPressed.java
+++ b/nifty-renderer-slick2d/src/main/java/de/lessvoid/nifty/slick2d/input/events/KeyboardEventPressed.java
@@ -37,6 +37,8 @@ public final class KeyboardEventPressed extends AbstractKeyboardEvent {
    */
   @Override
   public boolean sendToSlick(@Nonnull final InputListener listener) {
+    if(!listener.isAcceptingInput()) return false;
+    
     listener.keyPressed(getKey(), getCharacter());
     return true;
   }

--- a/nifty-renderer-slick2d/src/main/java/de/lessvoid/nifty/slick2d/input/events/KeyboardEventReleased.java
+++ b/nifty-renderer-slick2d/src/main/java/de/lessvoid/nifty/slick2d/input/events/KeyboardEventReleased.java
@@ -37,6 +37,8 @@ public final class KeyboardEventReleased extends AbstractKeyboardEvent {
    */
   @Override
   public boolean sendToSlick(@Nonnull final InputListener listener) {
+    if(!listener.isAcceptingInput()) return false;
+    
     listener.keyReleased(getKey(), getCharacter());
     return true;
   }

--- a/nifty-renderer-slick2d/src/main/java/de/lessvoid/nifty/slick2d/input/events/MouseEventClicked.java
+++ b/nifty-renderer-slick2d/src/main/java/de/lessvoid/nifty/slick2d/input/events/MouseEventClicked.java
@@ -54,6 +54,8 @@ public final class MouseEventClicked extends AbstractMouseEventButton {
    */
   @Override
   public boolean sendToSlick(@Nonnull final InputListener listener) {
+    if(!listener.isAcceptingInput()) return false;
+    
     listener.mouseClicked(getButton(), getX(), getY(), count);
     return true;
   }

--- a/nifty-renderer-slick2d/src/main/java/de/lessvoid/nifty/slick2d/input/events/MouseEventDragged.java
+++ b/nifty-renderer-slick2d/src/main/java/de/lessvoid/nifty/slick2d/input/events/MouseEventDragged.java
@@ -49,6 +49,8 @@ public final class MouseEventDragged extends AbstractMouseEventButton {
    */
   @Override
   public boolean sendToSlick(@Nonnull final InputListener listener) {
+    if(!listener.isAcceptingInput()) return false;
+    
     listener.mouseDragged(getX(), getY(), targetX, targetY);
     return true;
   }

--- a/nifty-renderer-slick2d/src/main/java/de/lessvoid/nifty/slick2d/input/events/MouseEventMoved.java
+++ b/nifty-renderer-slick2d/src/main/java/de/lessvoid/nifty/slick2d/input/events/MouseEventMoved.java
@@ -48,6 +48,8 @@ public final class MouseEventMoved extends AbstractMouseEvent {
    */
   @Override
   public boolean sendToSlick(@Nonnull final InputListener listener) {
+    if(!listener.isAcceptingInput()) return false;
+    
     listener.mouseMoved(getX(), getY(), targetX, targetY);
     return false;
   }

--- a/nifty-renderer-slick2d/src/main/java/de/lessvoid/nifty/slick2d/input/events/MouseEventPressed.java
+++ b/nifty-renderer-slick2d/src/main/java/de/lessvoid/nifty/slick2d/input/events/MouseEventPressed.java
@@ -36,6 +36,8 @@ public final class MouseEventPressed extends AbstractMouseEventButton {
    */
   @Override
   public boolean sendToSlick(@Nonnull final InputListener listener) {
+    if(!listener.isAcceptingInput()) return false;
+    
     listener.mousePressed(getButton(), getX(), getY());
     return true;
   }

--- a/nifty-renderer-slick2d/src/main/java/de/lessvoid/nifty/slick2d/input/events/MouseEventReleased.java
+++ b/nifty-renderer-slick2d/src/main/java/de/lessvoid/nifty/slick2d/input/events/MouseEventReleased.java
@@ -35,6 +35,8 @@ public final class MouseEventReleased extends AbstractMouseEventButton {
    */
   @Override
   public boolean sendToSlick(@Nonnull final InputListener listener) {
+    if(!listener.isAcceptingInput()) return false;
+    
     listener.mouseReleased(getButton(), getX(), getY());
     return true;
   }

--- a/nifty-renderer-slick2d/src/main/java/de/lessvoid/nifty/slick2d/input/events/MouseEventWheelMoved.java
+++ b/nifty-renderer-slick2d/src/main/java/de/lessvoid/nifty/slick2d/input/events/MouseEventWheelMoved.java
@@ -41,6 +41,8 @@ public final class MouseEventWheelMoved extends AbstractMouseEvent {
    */
   @Override
   public boolean sendToSlick(@Nonnull final InputListener listener) {
+    if(!listener.isAcceptingInput()) return false;
+    
     listener.mouseWheelMoved(wheelDelta);
     return true;
   }


### PR DESCRIPTION
You should consider that Slick InputListener doesn't have to want accept the events. In that case you should not forward those events to Slick.

That way is used in `org.newdawn.slick.Input#poll()`.
