### PR TITLE
fix: Fixed overlap calculation of rectangle

### DIFF
--- a/nifty/src/main/java/de/lessvoid/nifty/types/NiftyRect.java
+++ b/nifty/src/main/java/de/lessvoid/nifty/types/NiftyRect.java
@@ -78,18 +78,19 @@ public final class NiftyRect {
     return (other != null) && size.equals(other.size, tolerance) && origin.equals(other.origin, tolerance);
   }
 
-  public boolean isOverlapping(final NiftyRect other) {
-    float otherx0 = other.getOrigin().getX();
-    float othery0 = other.getOrigin().getY();
-    float otherx1 = other.getOrigin().getX() + other.getSize().getWidth() - 1.f;
-    float othery1 = other.getOrigin().getY() + other.getSize().getHeight() - 1.f;
+  public boolean isOverlapping(@Nonnull final NiftyRect other) {
+    float otherX0 = other.getOrigin().getX();
+    float otherY0 = other.getOrigin().getY();
+    float otherX1 = other.getOrigin().getX() + other.getSize().getWidth();
+    float otherY1 = other.getOrigin().getY() + other.getSize().getHeight();
 
     float x0 = getOrigin().getX();
     float y0 = getOrigin().getY();
-    float x1 = getOrigin().getX() + other.getSize().getWidth() - 1.f;
-    float y1 = getOrigin().getY() + other.getSize().getHeight() - 1.f;
+    float x1 = getOrigin().getX() + other.getSize().getWidth();
+    float y1 = getOrigin().getY() + other.getSize().getHeight();
 
-    return !((x0 > otherx1) || (x1 < otherx0) || (y0 > othery1) || (y1 < othery0));
+    return ((otherX1 < otherX0) || (otherX1 > x0)) && ((otherY1 < otherY0) || (otherY1 > y0)) &&
+        ((x1 < x0) || (x1 > otherX0)) && ((y1 < y0) || (y1 > otherY0));
   }
 
   @Override

--- a/nifty/src/test/java/de/lessvoid/nifty/types/NiftyRectTest.java
+++ b/nifty/src/test/java/de/lessvoid/nifty/types/NiftyRectTest.java
@@ -79,6 +79,13 @@ public class NiftyRectTest {
   }
 
   @Test
+  public void testOverlappingLeftBarely() {
+    NiftyRect rect1 = newNiftyRect(newNiftyPoint(100.f, 100.f), NiftySize.newNiftySize(10.f, 10.f));
+    NiftyRect rect2 = newNiftyRect(newNiftyPoint( 90.00001f, 100.f), NiftySize.newNiftySize(10.f, 10.f));
+    assertTrue(rect1.isOverlapping(rect2));
+  }
+
+  @Test
   public void testNotOverlappingRight() {
     NiftyRect rect1 = newNiftyRect(newNiftyPoint(100.f, 100.f), NiftySize.newNiftySize(10.f, 10.f));
     NiftyRect rect2 = newNiftyRect(newNiftyPoint(110.f, 100.f), NiftySize.newNiftySize(10.f, 10.f));
@@ -89,6 +96,13 @@ public class NiftyRectTest {
   public void testOverlappingRight() {
     NiftyRect rect1 = newNiftyRect(newNiftyPoint(100.f, 100.f), NiftySize.newNiftySize(10.f, 10.f));
     NiftyRect rect2 = newNiftyRect(newNiftyPoint(109.f, 100.f), NiftySize.newNiftySize(10.f, 10.f));
+    assertTrue(rect1.isOverlapping(rect2));
+  }
+
+  @Test
+  public void testOverlappingRightBarely() {
+    NiftyRect rect1 = newNiftyRect(newNiftyPoint(100.f, 100.f), NiftySize.newNiftySize(10.f, 10.f));
+    NiftyRect rect2 = newNiftyRect(newNiftyPoint(109.99999f, 100.f), NiftySize.newNiftySize(10.f, 10.f));
     assertTrue(rect1.isOverlapping(rect2));
   }
 
@@ -107,6 +121,13 @@ public class NiftyRectTest {
   }
 
   @Test
+  public void testOverlappingTopBarely() {
+    NiftyRect rect1 = newNiftyRect(newNiftyPoint(100.f, 100.f), NiftySize.newNiftySize(10.f, 10.f));
+    NiftyRect rect2 = newNiftyRect(newNiftyPoint(100.f, 90.00001f), NiftySize.newNiftySize(10.f, 10.f));
+    assertTrue(rect1.isOverlapping(rect2));
+  }
+
+  @Test
   public void testNotOverlappingBottom() {
     NiftyRect rect1 = newNiftyRect(newNiftyPoint(100.f, 100.f), NiftySize.newNiftySize(10.f, 10.f));
     NiftyRect rect2 = newNiftyRect(newNiftyPoint(100.f, 110.f), NiftySize.newNiftySize(10.f, 10.f));
@@ -117,6 +138,13 @@ public class NiftyRectTest {
   public void testOverlappingBottom() {
     NiftyRect rect1 = newNiftyRect(newNiftyPoint(100.f, 100.f), NiftySize.newNiftySize(10.f, 10.f));
     NiftyRect rect2 = newNiftyRect(newNiftyPoint(100.f, 109.f), NiftySize.newNiftySize(10.f, 10.f));
+    assertTrue(rect1.isOverlapping(rect2));
+  }
+
+  @Test
+  public void testOverlappingBottomBarely() {
+    NiftyRect rect1 = newNiftyRect(newNiftyPoint(100.f, 100.f), NiftySize.newNiftySize(10.f, 10.f));
+    NiftyRect rect2 = newNiftyRect(newNiftyPoint(100.f, 109.99999f), NiftySize.newNiftySize(10.f, 10.f));
     assertTrue(rect1.isOverlapping(rect2));
   }
 


### PR DESCRIPTION
fix: Fixed overlap calculation of rectangle

Fixed the overlapping calculation if the rectangles overlap by less than 1.f.
Also added some tests to cover those cases.
