### PR TITLE
Added a way to instantiate Controllers by using factories

### DIFF
--- a/nifty-core/src/main/java/de/lessvoid/nifty/Nifty.java
+++ b/nifty-core/src/main/java/de/lessvoid/nifty/Nifty.java
@@ -43,6 +43,7 @@ import de.lessvoid.nifty.input.mouse.MouseInputEventProcessor;
 import de.lessvoid.nifty.layout.Box;
 import de.lessvoid.nifty.layout.BoxConstraints;
 import de.lessvoid.nifty.layout.LayoutPart;
+import de.lessvoid.nifty.loaderv2.ControllerFactory;
 import de.lessvoid.nifty.loaderv2.NiftyLoader;
 import de.lessvoid.nifty.loaderv2.RootLayerFactory;
 import de.lessvoid.nifty.loaderv2.types.ControlDefinitionType;
@@ -130,6 +131,8 @@ public class Nifty {
   private final Map<String, RegisterEffectType> registeredEffects;
   @Nonnull
   private final Map<String, ScreenController> registeredScreenControllers;
+  @Nonnull
+  private final ControllerFactory controllerFactory;
 
   @Nonnull
   private final FlipFlop<List<DelayedMethodInvoke>> delayedMethodInvokes;
@@ -198,6 +201,7 @@ public class Nifty {
     controlDefinitions = new HashMap<String, ControlDefinitionType>();
     registeredEffects = new HashMap<String, RegisterEffectType>();
     registeredScreenControllers = new HashMap<String, ScreenController>();
+    controllerFactory = new ControllerFactory();
     controlStylesChanged = new HashSet<String>();
 
     delayedMethodInvokes = new FlipFlop<List<DelayedMethodInvoke>>(
@@ -1310,6 +1314,17 @@ public class Nifty {
       @Nonnull final ScreenController c = controllers[i];
       registeredScreenControllers.remove(c.getClass().getName());
     }
+  }
+
+  /**
+   * Obtain the controllerFactory, used to register and unregister Factories
+   * that create controllers.
+   * <p>
+   * @return
+   */
+  @Nonnull
+  public ControllerFactory getControllerFactory() {
+    return controllerFactory;
   }
 
   @Nonnull

--- a/nifty-core/src/main/java/de/lessvoid/nifty/controls/AbstractController.java
+++ b/nifty-core/src/main/java/de/lessvoid/nifty/controls/AbstractController.java
@@ -164,4 +164,9 @@ public abstract class AbstractController implements Controller, NiftyControl {
   public boolean isBound() {
     return bound;
   }
+
+  @Override
+  public void onEndScreen() {
+  }
+
 }

--- a/nifty-core/src/main/java/de/lessvoid/nifty/controls/Controller.java
+++ b/nifty-core/src/main/java/de/lessvoid/nifty/controls/Controller.java
@@ -71,4 +71,9 @@ public interface Controller {
    * @return true, the event has been handled and false, the event has not been handled
    */
   boolean inputEvent(@Nonnull NiftyInputEvent inputEvent);
+
+  /**
+   * Called when the screen ended.
+   */
+  void onEndScreen();
 }

--- a/nifty-core/src/main/java/de/lessvoid/nifty/controls/DefaultController.java
+++ b/nifty-core/src/main/java/de/lessvoid/nifty/controls/DefaultController.java
@@ -45,4 +45,8 @@ public class DefaultController implements Controller {
   @Override
   public void onFocus(final boolean getFocus) {
   }
+
+  @Override
+  public void onEndScreen() {
+  }
 }

--- a/nifty-core/src/main/java/de/lessvoid/nifty/controls/NiftyInputControl.java
+++ b/nifty-core/src/main/java/de/lessvoid/nifty/controls/NiftyInputControl.java
@@ -90,6 +90,7 @@ public class NiftyInputControl {
   }
 
   public void onEndScreen(@Nonnull final Nifty nifty, @Nonnull final Screen screen, @Nullable final String elementId) {
+    controller.onEndScreen();
     nifty.unsubscribeAnnotations(controller);
     if (elementId != null) {
       nifty.unsubscribeElement(screen, elementId);

--- a/nifty-core/src/main/java/de/lessvoid/nifty/loaderv2/ControllerFactory.java
+++ b/nifty-core/src/main/java/de/lessvoid/nifty/loaderv2/ControllerFactory.java
@@ -1,0 +1,71 @@
+package de.lessvoid.nifty.loaderv2;
+
+import de.lessvoid.nifty.controls.Controller;
+import de.lessvoid.nifty.tools.Factory;
+import de.lessvoid.xml.tools.ClassHelper;
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+/**
+ * This class is used to create Controllers other than through the empty
+ * constructor of a controller. If a factory is registered to a controller class
+ * type, it will be responsible to create the new instance of the controller.
+ * Otherwise, we try to instantiate the controller using an empty constructor.
+ *
+ * @author jfrenaud
+ */
+public class ControllerFactory {
+
+  /**
+   * The map containing the registered controllerFactories.
+   */
+  @Nonnull
+  private final Map<String, Factory<? extends Controller>> registeredControllersFactories = new HashMap<String, Factory<? extends Controller>>();
+
+  /**
+   * Register factory to create a controllers.
+   * <p>
+   * @param <C> any type of Controller
+   * @param controllerFactory The factory used to create a controller type.
+   * @param controllerClass The class type that the factory will create.
+   */
+  public <C extends Controller> void registerFactory(@Nonnull final Factory<C> controllerFactory, @Nonnull final Class<C> controllerClass) {
+    registeredControllersFactories.put(controllerClass.getName(), controllerFactory);
+  }
+
+  /**
+   * Unregister a factory previously registered, where the factory match the
+   * provided class type.
+   *
+   * @param <C> any type of Controller
+   * @param controllerClass The class type that the factory to remove can
+   * create.
+   */
+  public <C extends Controller> void unregisterFactory(@Nonnull final Class<C> controllerClass) {
+    registeredControllersFactories.remove(controllerClass.getName());
+  }
+
+  /**
+   * Creates a Controller given a fully qualified class name. If a factory is
+   * registered to a controller class type, it will be responsible to create the
+   * new instance of the controller. Otherwise, we try to instantiate the
+   * controller using an empty constructor.
+   *
+   * @param controllerClassName a fully qualified controller class name.
+   * @return a new Controller, or null if not able to create one.
+   */
+  @Nullable
+  public Controller create(@Nullable final String controllerClassName) {
+    if (controllerClassName == null) {
+      return null;
+    }
+    if (registeredControllersFactories.containsKey(controllerClassName)) {
+      return registeredControllersFactories.get(controllerClassName).createNew();
+    } else {
+      return ClassHelper.getInstance(controllerClassName, Controller.class);
+    }
+  }
+
+}

--- a/nifty-core/src/main/java/de/lessvoid/nifty/loaderv2/types/ElementType.java
+++ b/nifty-core/src/main/java/de/lessvoid/nifty/loaderv2/types/ElementType.java
@@ -224,14 +224,6 @@ public class ElementType extends XmlBaseType {
   }
 
   @Nullable
-  private Controller createLocalController(@Nullable final String controllerClassParam) {
-    if (controllerClassParam == null) {
-      return null;
-    }
-    return ClassHelper.getInstance(controllerClassParam, Controller.class);
-  }
-
-  @Nullable
   private NiftyInputControl createNiftyInputControl(
       @Nonnull final Attributes controlDefinitionAttributes,
       @Nonnull final Controller controller) {
@@ -344,7 +336,7 @@ public class ElementType extends XmlBaseType {
     // in case we have surviving special values (f.i. from applied controlDefinitions) we need to translate them too
     translateSpecialValues(nifty, screen);
 
-    resolveControllers(new LinkedList<Object>());
+    resolveControllers(nifty, new LinkedList<Object>());
   }
 
   @Override
@@ -413,14 +405,14 @@ public class ElementType extends XmlBaseType {
     return styleResolver;
   }
 
-  void resolveControllers(@Nonnull final Collection<Object> controllerParam) {
+  void resolveControllers(@Nonnull final Nifty nifty, @Nonnull final Collection<Object> controllerParam) {
     controllers = new LinkedList<Object>(controllerParam);
-    controller = createLocalController(getAttributes().get("controller"));
+    controller = nifty.getControllerFactory().create(getAttributes().get("controller"));
     if (controller != null) {
       controllers.addFirst(controller);
     }
     for (ElementType elementType : elements) {
-      elementType.resolveControllers(controllers);
+      elementType.resolveControllers(nifty, controllers);
     }
   }
 


### PR DESCRIPTION
-Added a way to create controllers other than using the default Constructor by registering a Factory to a specified Controller class type. If no factories are found for a controller type, the default constructor is used by default
-Added onEndScreen() method to Controller class since it had already onStartScreen()
