### PR TITLE
Fixed a bug to restore children's effects

### DIFF
--- a/nifty-core/src/main/java/de/lessvoid/nifty/effects/EffectProcessorImpl.java
+++ b/nifty-core/src/main/java/de/lessvoid/nifty/effects/EffectProcessorImpl.java
@@ -89,6 +89,7 @@ public class EffectProcessorImpl implements EffectProcessor {
       Effect e = pushedEffects.get(i);
       activate(listener, e.getAlternate(), e.getCustomKey());
     }
+    pushedEffects.clear();
   }
 
   @Override

--- a/nifty-core/src/main/java/de/lessvoid/nifty/elements/Element.java
+++ b/nifty-core/src/main/java/de/lessvoid/nifty/elements/Element.java
@@ -1066,6 +1066,17 @@ public class Element implements NiftyEvent, EffectManager.Notify {
     }
   }
 
+  public void restoreForShow() {
+    effectManager.restoreForShow();
+    if (children != null) {
+      final int childrenCount = children.size();
+      for (int i = 0; i < childrenCount; i++) {
+        Element w = children.get(i);
+        w.restoreForShow();
+      }
+    }
+  }
+
   public void resetForHide() {
     effectManager.resetForHide();
     if (children != null) {
@@ -1504,7 +1515,7 @@ public class Element implements NiftyEvent, EffectManager.Notify {
 
   private void internalShow() {
     visible = true;
-    effectManager.restoreForShow();
+    restoreForShow();
 
     if (id != null) {
       nifty.publishEvent(id, new ElementShowEvent(this));


### PR DESCRIPTION
Fixed a bug where effects for children elements were pushed for restore, but only the actual element was restored and not the children elements as well.
