### PR TITLE
fix: NiftyTree - Fixed implementation of Iterable

### DIFF
--- a/nifty/src/main/java/de/lessvoid/niftyinternal/tree/InternalNiftyTree.java
+++ b/nifty/src/main/java/de/lessvoid/niftyinternal/tree/InternalNiftyTree.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Nifty GUI Community
+ * Copyright (c) 2016, Nifty GUI Community
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -200,7 +200,7 @@ public class InternalNiftyTree {
       @Nonnull final NiftyTreeNodeConverter<T> converter,
       @Nonnull final NiftyTreeNodeControl control,
       @Nonnull final NiftyTreeNode startTreeNode) {
-    return makeIterable(startTreeNode.iterator(predicate, converter, control));
+    return startTreeNode.iterable(predicate, converter, control);
   }
 
   @Nullable
@@ -262,15 +262,6 @@ public class InternalNiftyTree {
     NiftyTreeNode childTreeNode = new NiftyTreeNode(child);
     parent.addChild(childTreeNode);
     registerNode(child, childTreeNode);
-  }
-
-  private <X> Iterable<X> makeIterable(final Iterator<X> iterator) {
-    return new Iterable<X>() {
-      @Override
-      public Iterator<X> iterator() {
-        return iterator;
-      }
-    };
   }
 
   private void assertNotNull(final NiftyNodeImpl rootNode) {

--- a/nifty/src/main/java/de/lessvoid/niftyinternal/tree/NiftyTreeNode.java
+++ b/nifty/src/main/java/de/lessvoid/niftyinternal/tree/NiftyTreeNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, Nifty GUI Community
+ * Copyright (c) 2016, Nifty GUI Community
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -74,6 +74,21 @@ public class NiftyTreeNode {
 
   public void setParent(final NiftyTreeNode parent) {
     this.parent = parent;
+  }
+
+  public <T> Iterable<T> iterable(@Nonnull final NiftyTreeNodePredicate predicate,
+                                  @Nonnull final NiftyTreeNodeConverter<T> converter,
+                                  @Nonnull final NiftyTreeNodeControl control) {
+    if (getChildren().isEmpty()) {
+      return Collections.emptyList();
+    }
+
+    return new Iterable<T>() {
+      @Override
+      public Iterator<T> iterator() {
+        return NiftyTreeNode.this.iterator(predicate, converter, control);
+      }
+    };
   }
 
   public <T> Iterator<T> iterator(@Nonnull final NiftyTreeNodePredicate predicate,


### PR DESCRIPTION
The old implementation of the iterable returned by child nodes did not
ensure that the iteration starts from the beginning in case a new
iterator is requested as it is expected from a non-consuming iterator.

The new implementation creates a new iterator instance each time the
iteration is requested to fulfill this requirement. Currently this
problem does not occur because each iterable instance is only
iterated once. But this may cause trouble in future.
