### PR TITLE
docs: Documentation Example for AbsoluteLayoutNode

### DIFF
--- a/nifty/pom.xml
+++ b/nifty/pom.xml
@@ -38,7 +38,7 @@
     <plugins>
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
-        <version>2.2-beta-5</version>
+        <version>2.6</version>
         <configuration>
           <archive>
             <manifest>
@@ -53,12 +53,12 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-site-plugin</artifactId>
-        <version>3.0-beta-3</version>
+        <version>3.4</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-source-plugin</artifactId>
-        <version>2.0.4</version>
+        <version>2.4</version>
         <executions>
           <execution>
             <id>attach-sources</id>
@@ -98,18 +98,19 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-report-plugin</artifactId>
-        <version>2.5</version>
+        <version>2.19</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>2.9.1</version>
+        <version>2.10.3</version>
         <configuration>
           <excludePackageNames>de.lessvoid.niftyinternal</excludePackageNames>
           <links>
-            <link>http://java.sun.com/j2se/1.5.0/docs/api</link>
+            <link>http://docs.oracle.com/javase/6/docs/api/</link>
           </links>
           <additionalparam>-Xdoclint:none</additionalparam>
+          <docfilessubdirs>true</docfilessubdirs>
         </configuration>
       </plugin>
     </plugins>

--- a/nifty/src/main/java/de/lessvoid/nifty/node/AbsoluteLayoutChildNode.java
+++ b/nifty/src/main/java/de/lessvoid/nifty/node/AbsoluteLayoutChildNode.java
@@ -1,3 +1,30 @@
+/*
+ * Copyright (c) 2016, Nifty GUI Community
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package de.lessvoid.nifty.node;
 
 import de.lessvoid.nifty.spi.node.NiftyNode;
@@ -125,6 +152,6 @@ public final class AbsoluteLayoutChildNode implements NiftyNode {
   @Nonnull
   @Override
   public String toString() {
-    return "(AbsoluteLayoutChildNodeImpl) x [" + getX() + "px] y [" + getY() + "px]" ;
+    return "(AbsoluteLayoutChildNode) x [" + getX() + "px] y [" + getY() + "px]" ;
   }
 }

--- a/nifty/src/main/java/de/lessvoid/nifty/node/AbsoluteLayoutChildNode.java
+++ b/nifty/src/main/java/de/lessvoid/nifty/node/AbsoluteLayoutChildNode.java
@@ -9,26 +9,52 @@ import javax.annotation.Nonnull;
 import static de.lessvoid.nifty.types.NiftyPoint.newNiftyPoint;
 
 /**
- * This is a child layout node for the {@link AbsoluteLayoutNode}. This node allows to set the x and y coordinate
- * where the node is placed. Aside from the additional information applied, acts in the same way as a
- * {@link SimpleLayoutNode}. So it just arranges any child item to it's full available size.
+ * This is a child layout node for the {@link AbsoluteLayoutNode}.
+ *
+ * This node allows to set the x and y coordinate where the node is placed. Aside from the additional information
+ * applied, acts in the same way as a {@link SimpleLayoutNode}. So it just arranges any child item to it's full
+ * available size. The size this node requests will match the maximum height and width of all child nodes.
  *
  * @author Martin Karing &lt;nitram@illarion.org&gt;
+ * @see AbsoluteLayoutNode for additional documentation
  */
 public final class AbsoluteLayoutChildNode implements NiftyNode {
   @Nonnull
   private final AbsoluteLayoutChildNodeImpl implementation;
 
+  /**
+   * Create a new node that will be placed at the coordinates specified by the {@code point} parameter.
+   *
+   * @param point the point that defines the location where the node is placed
+   * @return the newly created node
+   */
   @Nonnull
   public static AbsoluteLayoutChildNode absoluteLayoutChildNode(@Nonnull final NiftyPoint point) {
     return new AbsoluteLayoutChildNode(point);
   }
 
+  /**
+   * Create a new node that will be placed at the coordinates specified by the {@code x} and {@code y} parameters.
+   * <p />
+   * This function creates a instanced of {@link NiftyPoint} to store the coordinates. The parameters are subject to the
+   * limitations set by this class.
+   *
+   * @param x the x coordinate of the point
+   * @param y the y coordinate of the point
+   * @return the newly created node
+   * @throws IllegalArgumentException If one or both parameters are not finite values.
+   * @see NiftyPoint
+   */
   @Nonnull
   public static AbsoluteLayoutChildNode absoluteLayoutChildNode(final float x, final float y) {
     return absoluteLayoutChildNode(newNiftyPoint(x, y));
   }
 
+  /**
+   * Create a new node that will be placed at {@code 0 0}.
+   *
+   * @return The newly created node
+   */
   @Nonnull
   public static AbsoluteLayoutChildNode absoluteLayoutChildNode() {
     return absoluteLayoutChildNode(0.f, 0.f);
@@ -42,18 +68,42 @@ public final class AbsoluteLayoutChildNode implements NiftyNode {
     this.implementation = implementation;
   }
 
+  /**
+   * Get the X coordinate this node will be placed at.
+   *
+   * @return the x coordinate
+   */
   public float getX() {
     return getPoint().getX();
   }
 
+  /**
+   * Change the X coordinate this node will be placed at.
+   * <p />
+   * Changing this value will trigger the a update of the layout.
+   *
+   * @param x the new x coordinate
+   */
   public void setX(final float x) {
     setPoint(newNiftyPoint(x, getY()));
   }
 
+  /**
+   * Get the Y coordinate this node will be placed at.
+   *
+   * @return the y coordinate
+   */
   public float getY() {
     return getPoint().getY();
   }
 
+  /**
+   * Change the Y coordinate this node will be placed at.
+   * <p />
+   * Changing this value will trigger the a update of the layout.
+   *
+   * @param y the new y coordinate
+   */
   public void setY(final float y) {
     setPoint(newNiftyPoint(getX(), y));
   }

--- a/nifty/src/main/java/de/lessvoid/nifty/node/AbsoluteLayoutNode.java
+++ b/nifty/src/main/java/de/lessvoid/nifty/node/AbsoluteLayoutNode.java
@@ -4,10 +4,27 @@ import de.lessvoid.nifty.spi.node.NiftyNode;
 import de.lessvoid.nifty.spi.node.NiftyNodeImpl;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 /**
  * This is a layout node for a absolute value. It will place every single child node at 0,0 unless it is a
  * {@link AbsoluteLayoutChildNode} that supports setting a location.
+ * <p>
+ *   This layout will arrange it's children based on their desired size. So a children are <b>not</b> stretched to the
+ *   full available size.
+ * </p>
+ * <h3>Layout Concept</h3>
+ * <p>
+ *   <img src="doc-files/AbsoluteLayoutNode-1.svg" alt="Concept Image" />
+ * </p>
+ * <ul>
+ *   <li><b>X:</b> {@link AbsoluteLayoutChildNode#getX()}</li>
+ *   <li><b>Y:</b> {@link AbsoluteLayoutChildNode#getY()}</li>
+ * </ul>
+ * <p>
+ *   This node does not ensure that the child nodes are fully within the parent area. In case the X and Y values are
+ *   chosen badly, the objects will be placed outside of the area of this node.
+ * </p>
  *
  * @author Martin Karing &lt;nitram@illarion.org&gt;
  */
@@ -15,6 +32,14 @@ public final class AbsoluteLayoutNode implements NiftyNode {
   @Nonnull
   private final AbsoluteLayoutNodeImpl implementation;
 
+  /**
+   * Create a new instance of the absolute layout node.
+   * <p />
+   * There are no parameters to this node, because the actual placement of the nodes is defined by x and y
+   * coordinates defined in the {@link AbsoluteLayoutChildNode}s.
+   *
+   * @return the new instance
+   */
   @Nonnull
   public static AbsoluteLayoutNode absoluteLayoutNode() {
     return new AbsoluteLayoutNode();
@@ -31,6 +56,16 @@ public final class AbsoluteLayoutNode implements NiftyNode {
   @Nonnull
   NiftyNodeImpl<AbsoluteLayoutNode> getImpl() {
     return implementation;
+  }
+
+  @Override
+  public boolean equals(@Nullable  final Object obj) {
+    return (obj instanceof AbsoluteLayoutNode) && ((AbsoluteLayoutNode) obj).implementation.equals(implementation);
+  }
+
+  @Override
+  public int hashCode() {
+    return implementation.hashCode();
   }
 
   @Nonnull

--- a/nifty/src/main/java/de/lessvoid/niftyinternal/render/batch/BatchManager.java
+++ b/nifty/src/main/java/de/lessvoid/niftyinternal/render/batch/BatchManager.java
@@ -1,17 +1,17 @@
 /*
- * Copyright (c) 2015, Nifty GUI Community 
- * All rights reserved. 
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions are 
- * met: 
- * 
- *  * Redistributions of source code must retain the above copyright 
- *    notice, this list of conditions and the following disclaimer. 
- *  * Redistributions in binary form must reproduce the above copyright 
- *    notice, this list of conditions and the following disclaimer in the 
- *    documentation and/or other materials provided with the distribution. 
- * 
+ * Copyright (c) 2016, Nifty GUI Community
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
  * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND 
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR 
@@ -37,6 +37,8 @@ import de.lessvoid.niftyinternal.math.Mat4;
 import de.lessvoid.nifty.spi.NiftyRenderDevice;
 import de.lessvoid.nifty.spi.NiftyTexture;
 
+import javax.annotation.Nonnull;
+
 public class BatchManager {
   private List<Batch<?>> activeBatches = new ArrayList<Batch<?>>();
 
@@ -54,45 +56,19 @@ public class BatchManager {
     requestBatch(
         ChangeCompositeOperationBatch.class,
         compositeOperation,
-        new BatchFactory<ChangeCompositeOperationBatch>() {
-          @Override
-          public ChangeCompositeOperationBatch createBatch() {
-            return new ChangeCompositeOperationBatch(compositeOperation);
-          }
-        });
+        ChangeCompositeOperationBatchFactory.Instance);
   }
 
   public void addBeginPath() {
-    requestBatch(
-        BeginPathBatch.class,
-        null,
-        new BatchFactory<BeginPathBatch>() {
-          @Override
-          public BeginPathBatch createBatch() {
-            return new BeginPathBatch();
-          }
-        });
+    requestBatch(BeginPathBatch.class, null, BeginPathBatchFactory.Instance);
   }
 
   public void addEndPath(final NiftyColor lineColor) {
-    requestBatch(
-        EndPathBatch.class,
-        null,
-        new BatchFactory<EndPathBatch>() {
-          @Override
-          public EndPathBatch createBatch() {
-            return new EndPathBatch(lineColor);
-          }
-        });
+    requestBatch(EndPathBatch.class, lineColor, EndPathBatchFactory.Instance);
   }
 
   public void addTextureQuad(final NiftyTexture niftyTexture, final Mat4 mat, final NiftyColor color) {
-    TextureBatch batch = requestBatch(TextureBatch.class, niftyTexture, new BatchFactory<TextureBatch>() {
-      @Override
-      public TextureBatch createBatch() {
-        return new TextureBatch(niftyTexture);
-      }
-    });
+    TextureBatch batch = requestBatch(TextureBatch.class, niftyTexture, TextureBatchFactory.Instance);
     batch.add(
         0.0, 0.0,
         niftyTexture.getWidth(), niftyTexture.getHeight(),
@@ -114,12 +90,7 @@ public class BatchManager {
       final double u1,
       final double v1,
       final NiftyColor color) {
-    TextureBatch batch = requestBatch(TextureBatch.class, niftyTexture, new BatchFactory<TextureBatch>() {
-      @Override
-      public TextureBatch createBatch() {
-        return new TextureBatch(niftyTexture);
-      }
-    });
+    TextureBatch batch = requestBatch(TextureBatch.class, niftyTexture, TextureBatchFactory.Instance);
     batch.add(x, y, width, height, u0, v0, u1, v1, mat, color);
   }
 
@@ -130,14 +101,10 @@ public class BatchManager {
       final double y1,
       final Mat4 mat,
       final NiftyLinearGradient fillLinearGradient) {
-    final LinearGradient gradient = new LinearGradient(x0, y0, x1, y1, fillLinearGradient);
+    LinearGradient gradient = new LinearGradient(x0, y0, x1, y1, fillLinearGradient);
 
-    LinearGradientQuadBatch batch = requestBatch(LinearGradientQuadBatch.class, gradient, new BatchFactory<LinearGradientQuadBatch>() {
-      @Override
-      public LinearGradientQuadBatch createBatch() {
-        return new LinearGradientQuadBatch(gradient);
-      }
-    });
+    LinearGradientQuadBatch batch = requestBatch(LinearGradientQuadBatch.class, gradient,
+        LinearGradientQuadBatchFactory.Instance);
     batch.add(x0, y0, x1, y1, mat);
   }
 
@@ -148,22 +115,12 @@ public class BatchManager {
       final double y1,
       final NiftyColor c,
       final Mat4 mat) {
-    ColorQuadBatch batch = requestBatch(ColorQuadBatch.class, null, new BatchFactory<ColorQuadBatch>() {
-      @Override
-      public ColorQuadBatch createBatch() {
-        return new ColorQuadBatch();
-      }
-    });
+    ColorQuadBatch batch = requestBatch(ColorQuadBatch.class, null, ColorQuadBatchFactory.Instance);
     batch.add(x0, y0, x1, y1, c, c, c, c, mat);
   }
 
   public void addCustomShader(final String shaderId) {
-    requestBatch(CustomShaderBatch.class, shaderId, new BatchFactory<CustomShaderBatch>() {
-      @Override
-      public CustomShaderBatch createBatch() {
-        return new CustomShaderBatch(shaderId);
-      }
-    });
+    requestBatch(CustomShaderBatch.class, shaderId, CustomShaderBatchFactory.Instance);
   }
 
   public void addLineVertex(
@@ -171,7 +128,7 @@ public class BatchManager {
       final float y,
       final Mat4 mat,
       final LineParameters lineParameters) {
-    LineBatch batch = requestBatch(LineBatch.class, lineParameters, createLineBatchFactory(lineParameters));
+    LineBatch batch = requestBatch(LineBatch.class, lineParameters, LineBatchFactory.Instance);
     batch.add(x, y, mat);
   }
 
@@ -180,7 +137,7 @@ public class BatchManager {
       final float y,
       final Mat4 mat,
       final LineParameters lineParameters) {
-    LineBatch batch = addBatch(createLineBatchFactory(lineParameters));
+    LineBatch batch = addBatch(LineBatchFactory.Instance, lineParameters);
     batch.add(x, y, mat);
   }
 
@@ -189,28 +146,16 @@ public class BatchManager {
       final double y,
       final Mat4 mat,
       final ArcParameters arcParameters) {
-    BatchFactory<ArcBatch> batchFactory = new BatchFactory<ArcBatch>() {
-      @Override
-      public ArcBatch createBatch() {
-        return new ArcBatch(arcParameters);
-      }
-    };
-    ArcBatch batch = requestBatch(ArcBatch.class, arcParameters, batchFactory);
+    ArcBatch batch = requestBatch(ArcBatch.class, arcParameters, ArcBatchFactory.Instance);
     batch.add(x, y, arcParameters.getRadius(), mat);
   }
 
   public void addTriangleFanVertex(final float x, final float y, final Mat4 mat, final boolean forceNewBatch, final boolean last) {
-    BatchFactory<TriangleFanBatch> batchFactory = new BatchFactory<TriangleFanBatch>() {
-      @Override
-      public TriangleFanBatch createBatch() {
-        return new TriangleFanBatch();
-      }
-    };
     TriangleFanBatch batch;
     if (forceNewBatch) {
-      batch = addBatch(batchFactory);
+      batch = addBatch(TriangleFanBatchFactory.Instance, null);
     } else {
-      batch = requestBatch(TriangleFanBatch.class, (Void) null, batchFactory);
+      batch = requestBatch(TriangleFanBatch.class, null, TriangleFanBatchFactory.Instance);
     }
     if (forceNewBatch) {
       batch.enableStartPathBatch();
@@ -221,40 +166,123 @@ public class BatchManager {
     batch.add(x, y, mat);
   }
 
+  @SuppressWarnings("unchecked")
   private <T extends Batch<P>, P> T requestBatch(
       final Class<T> clazz,
       final P param,
-      final BatchFactory<T> batchFactory) {
+      final BatchFactory<T, P> batchFactory) {
     if (activeBatches.isEmpty()) {
-      return addBatch(batchFactory);
+      return addBatch(batchFactory, param);
     }
     Batch<P> lastBatch = (Batch<P>) activeBatches.get(activeBatches.size() - 1);
     if (!clazz.isInstance(lastBatch)) {
-      return addBatch(batchFactory);
+      return addBatch(batchFactory, param);
     }
     if (!lastBatch.requiresNewBatch(param)) {
       return (T) lastBatch;
     }
-    return addBatch(batchFactory);
+    return addBatch(batchFactory, param);
   }
 
-  private <T extends Batch<P>, P> T addBatch(final BatchFactory<T> batchFactory) {
-    T batch = batchFactory.createBatch();
+  private <T extends Batch<P>, P> T addBatch(final BatchFactory<T, P> batchFactory, final P param) {
+    T batch = batchFactory.createBatch(param);
     activeBatches.add(batch);
     return batch;
   }
 
-  private BatchFactory<LineBatch> createLineBatchFactory(final LineParameters lineParameters) {
-    BatchFactory<LineBatch> batchFactory = new BatchFactory<LineBatch>() {
-      @Override
-      public LineBatch createBatch() {
-        return new LineBatch(lineParameters);
-      }
-    };
-    return batchFactory;
+  private interface BatchFactory<T extends Batch<P>, P> {
+    @Nonnull
+    T createBatch(P param);
   }
 
-  private interface BatchFactory<T> {
-    T createBatch();
+  private enum ArcBatchFactory implements BatchFactory<ArcBatch, ArcParameters> {
+    Instance;
+    @Nonnull
+    @Override
+    public ArcBatch createBatch(final ArcParameters param) {
+      return new ArcBatch(param);
+    }
+  }
+
+  private enum BeginPathBatchFactory implements BatchFactory<BeginPathBatch, Void> {
+    Instance;
+    @Nonnull
+    @Override
+    public BeginPathBatch createBatch(final Void param) {
+      return new BeginPathBatch();
+    }
+  }
+
+  private enum ChangeCompositeOperationBatchFactory
+      implements BatchFactory<ChangeCompositeOperationBatch, NiftyCompositeOperation> {
+    Instance;
+    @Nonnull
+    @Override
+    public ChangeCompositeOperationBatch createBatch(final NiftyCompositeOperation param) {
+      return new ChangeCompositeOperationBatch(param);
+    }
+  }
+
+  private enum ColorQuadBatchFactory implements BatchFactory<ColorQuadBatch, Void> {
+    Instance;
+    @Nonnull
+    @Override
+    public ColorQuadBatch createBatch(final Void param) {
+      return new ColorQuadBatch();
+    }
+  }
+
+  private enum CustomShaderBatchFactory implements BatchFactory<CustomShaderBatch, String> {
+    Instance;
+    @Nonnull
+    @Override
+    public CustomShaderBatch createBatch(final String param) {
+      return new CustomShaderBatch(param);
+    }
+  }
+
+  private enum EndPathBatchFactory implements BatchFactory<EndPathBatch, NiftyColor> {
+    Instance;
+    @Nonnull
+    @Override
+    public EndPathBatch createBatch(final NiftyColor param) {
+      return new EndPathBatch(param);
+    }
+  }
+
+  private enum LinearGradientQuadBatchFactory implements BatchFactory<LinearGradientQuadBatch, LinearGradient> {
+    Instance;
+    @Nonnull
+    @Override
+    public LinearGradientQuadBatch createBatch(final LinearGradient param) {
+      return new LinearGradientQuadBatch(param);
+    }
+  }
+
+  private enum LineBatchFactory implements BatchFactory<LineBatch, LineParameters> {
+    Instance;
+    @Nonnull
+    @Override
+    public LineBatch createBatch(final LineParameters param) {
+      return new LineBatch(param);
+    }
+  }
+
+  private enum TextureBatchFactory implements BatchFactory<TextureBatch, NiftyTexture> {
+    Instance;
+    @Nonnull
+    @Override
+    public TextureBatch createBatch(final NiftyTexture param) {
+      return new TextureBatch(param);
+    }
+  }
+
+  private enum TriangleFanBatchFactory implements BatchManager.BatchFactory<TriangleFanBatch, Void> {
+    Instance;
+    @Nonnull
+    @Override
+    public TriangleFanBatch createBatch(final Void param) {
+      return new TriangleFanBatch();
+    }
   }
 }

--- a/nifty/src/main/java/de/lessvoid/niftyinternal/render/batch/EndPathBatch.java
+++ b/nifty/src/main/java/de/lessvoid/niftyinternal/render/batch/EndPathBatch.java
@@ -1,17 +1,17 @@
 /*
- * Copyright (c) 2015, Nifty GUI Community 
- * All rights reserved. 
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions are 
- * met: 
- * 
- *  * Redistributions of source code must retain the above copyright 
- *    notice, this list of conditions and the following disclaimer. 
- *  * Redistributions in binary form must reproduce the above copyright 
- *    notice, this list of conditions and the following disclaimer in the 
- *    documentation and/or other materials provided with the distribution. 
- * 
+ * Copyright (c) 2016, Nifty GUI Community
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
  * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND 
  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR 
@@ -29,7 +29,7 @@ package de.lessvoid.niftyinternal.render.batch;
 import de.lessvoid.nifty.types.NiftyColor;
 import de.lessvoid.nifty.spi.NiftyRenderDevice;
 
-public class EndPathBatch implements Batch<Void> {
+public class EndPathBatch implements Batch<NiftyColor> {
   private final NiftyColor lineColor;
 
   public EndPathBatch(final NiftyColor lineColor) {
@@ -42,7 +42,7 @@ public class EndPathBatch implements Batch<Void> {
   }
 
   @Override
-  public boolean requiresNewBatch(final Void param) {
+  public boolean requiresNewBatch(final NiftyColor param) {
     return true;
   }
 }

--- a/nifty/src/main/javadoc/de/lessvoid/nifty/node/doc-files/AbsoluteLayoutNode-1.svg
+++ b/nifty/src/main/javadoc/de/lessvoid/nifty/node/doc-files/AbsoluteLayoutNode-1.svg
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+  ~ Copyright (c) 2016, Nifty GUI Community
+  ~ All rights reserved.
+  ~
+  ~ Redistribution and use in source and binary forms, with or without
+  ~ modification, are permitted provided that the following conditions are
+  ~ met:
+  ~
+  ~  * Redistributions of source code must retain the above copyright
+  ~    notice, this list of conditions and the following disclaimer.
+  ~  * Redistributions in binary form must reproduce the above copyright
+  ~    notice, this list of conditions and the following disclaimer in the
+  ~    documentation and/or other materials provided with the distribution.
+  ~
+  ~ THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+  ~ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  ~ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+  ~ PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE
+  ~ LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+  ~ CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+  ~ SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+  ~ INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+  ~ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+  ~ ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+  ~ THE POSSIBILITY OF SUCH DAMAGE.
+  -->
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1"
+     width="352" height="232">
+  <title>Absolute Layout Concept</title>
+  <style type="text/css">
+    * {
+      font-size: 14px;
+      font-family: "DejaVu Sans Mono",monospace;
+    }
+    marker {
+        overflow:visible
+    }
+    g.parentNode {
+      stroke:#474747;
+      fill:#474747;
+    }
+    g.parentNode text {
+      stroke:none;
+    }
+    g.parentNode > text {
+      fill: #353833;
+      font-weight: bold;
+    }
+    g.childNode {
+      stroke:#4A6782;
+      fill:#4A6782;
+    }
+    g.childNode text {
+      stroke:none;
+    }
+    g.green line {
+      stroke:darkgreen;
+      stroke-width:2;
+      marker-start:url(#ArrowGreenEnd);
+      marker-end:url(#ArrowGreenStart)
+    }
+    g.green text {
+        fill:darkgreen;
+    }
+    g.red line {
+      stroke:darkred;
+      stroke-width:2;
+      marker-start:url(#ArrowRedStart);
+      marker-end:url(#ArrowRedEnd)
+    }
+    g.red text {
+        fill:darkred;
+    }
+    line.limit {
+      stroke:#474747;
+      stroke-width:1;
+      stroke-dasharray: 3 3;
+    }
+  </style>
+  <defs>
+    <polygon points="0,0 5,2.5 5,-2.5" id="MarkerTip" />
+    <marker orient="auto" id="ArrowGreenEnd">
+      <use xlink:href="#MarkerTip" style="fill:darkgreen;fill-rule:evenodd" transform="scale(-1,1)" />
+    </marker>
+    <marker orient="auto" id="ArrowGreenStart">
+      <use xlink:href="#MarkerTip" style="fill:darkgreen;fill-rule:evenodd" />
+    </marker>
+    <marker orient="auto" id="ArrowRedStart">
+      <use xlink:href="#MarkerTip" style="fill:darkred;fill-rule:evenodd" />
+    </marker>
+    <marker orient="auto" id="ArrowRedEnd">
+      <use xlink:href="#MarkerTip" style="fill:darkred;fill-rule:evenodd" transform="scale(-1, 1)" />
+    </marker>
+  </defs>
+  <g transform="translate(10, 10)" class="parentNode">
+    <rect style="fill:none;stroke-width:4" width="340" height="220" />
+    <text x="340" y="0" text-anchor="end" dominant-baseline="hanging" transform="translate(-5, 5)">
+      AbsoluteLayoutNode
+    </text>
+    <g transform="translate(50, 50)" class="childNode">
+      <rect style="fill:none;stroke-width:4" width="235" height="130" />
+      <text x="235" y="130" text-anchor="end" transform="translate(-5, -5)">
+        AbsoluteLayoutChildNode
+      </text>
+      <!-- height marker -->
+      <g transform="translate(250, 0)" class="red">
+        <line x1="0" y1="0" x2="0" y2="130" />
+        <text y="65" text-anchor="middle" dominant-baseline="hanging" transform="rotate(-90, 0, 65) translate(0, 8)">
+          desired height
+        </text>
+      </g>
+      <line class="limit" x1="235" y1="0" x2="265" y2="0" />
+      <line class="limit" x1="235" y1="130" x2="265" y2="130" />
+      <!-- width marker -->
+      <g transform="translate(0, 145)" class="red">
+        <line x1="0" y1="0" x2="235" y2="0" />
+        <text x="117.5" text-anchor="middle" dominant-baseline="hanging" transform="translate(0, 3)">
+          desired width
+        </text>
+      </g>
+      <line class="limit" x1="0" y1="130" x2="0" y2="160" />
+      <line class="limit" x1="235" y1="130" x2="235" y2="160" />
+    </g>
+    <g transform="translate(70, 0)" class="green">
+      <line x1="0" y1="0" x2="0" y2="50" />
+      <text y="25" text-anchor="end" dominant-baseline="middle" transform="translate(-5, 0)">
+        Y
+      </text>
+    </g>
+    <g transform="translate(0, 90)" class="green">
+      <line x1="0" y1="0" x2="50" y2="0" />
+      <text x="25" text-anchor="middle" transform="translate(0, -5)">
+        X
+      </text>
+    </g>
+  </g>
+</svg>

--- a/nifty/src/site/apt/layout.apt
+++ b/nifty/src/site/apt/layout.apt
@@ -1,0 +1,26 @@
+Nifty 2.0 Layout
+
+* Basic Concept
+
+  The basic concept of the Nifty-GUI layout is that it processes the layout in two stages:
+
+    [[1]] Measure
+
+    [[2]] Arrange
+
+  The first stage is the measurement stage. During that stage the elements calculate and report the optimal size they
+  require to display their content. This calculation happens based on the available size that is reported by the
+  parent node. If a layout node splits it's area in two equally it will report only half of it's original size to the
+  child nodes. This way the nodes are able to calculate their layout according to the present restrictions. This may be
+  relevant in case nodes need to wrap their children into lines or columns and require more height.
+
+  The calculated size is treated as desired size. It is not a requirement for the layout. Most of the layout nodes are
+  not able to arrange the children at exactly the same size as they requested.
+
+  The second stage of the layout is the arrangement stage. During this stage each nodes receives it's exact position
+  and size relative to the root node. The default behavior for the layout is to use all space that is available to
+  place the child nodes, regardless of their desired size. Some of the layout nodes are able to handle nodes that
+  request a smaller surface in one dimension or in both. These layout nodes will use the desired size of their children.
+  An example for such a layout node is
+  the {{{./apidocs/de/lessvoid/nifty/node/AbsoluteLayoutNode.html}AbsoluteLayoutNode}}. This node is able to place
+  child nodes freely on it's surface and layout them according to their desired size in both dimensions.

--- a/nifty/src/site/site.xml
+++ b/nifty/src/site/site.xml
@@ -16,5 +16,8 @@
     </breadcrumbs>
     <menu ref="reports"/>
     <menu ref="modules" />
+    <menu name="Manual">
+      <item name="Layout" href="layout.html" />
+    </menu>
   </body>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,19 @@
       </roles>
     </developer>
   </developers>
+  <contributors>
+    <contributor>
+      <name>Martin Karing</name>
+      <email>nitram@illarion.org</email>
+      <organization>Illarion e.V.</organization>
+      <organizationUrl>http://illarion.org</organizationUrl>
+      <timezone>Europe/Berlin</timezone>
+      <roles>
+        <role>developer</role>
+        <role>tester</role>
+      </roles>
+    </contributor>
+  </contributors>
   <properties>
     <!-- The CoreGL version we currently use since this is required in multiple modules -->
     <coregl-utils.version>2.0-SNAPSHOT</coregl-utils.version>


### PR DESCRIPTION
This is a example how the layout documentation could look like.

I had to update some of the dependencies for the site generation, because some contained bugs with the things I wanted to do (copying additional resources) and some referenced strange beta versions of dependencies that got proper releases already. The site generation still works and looks good.

Please have a look at the documentation I created for the first layout node and if that is the way we want to do this or if you have a different style of documentation in mind. For the layout nodes my idea is that one picture tells the user much more than extensive descriptions.
