### PR TITLE
fix: Sampler state 

### DIFF
--- a/nifty-core/src/main/java/de/lessvoid/nifty/render/batch/core/CoreProfileSaveGLState.java
+++ b/nifty-core/src/main/java/de/lessvoid/nifty/render/batch/core/CoreProfileSaveGLState.java
@@ -35,34 +35,49 @@ public class CoreProfileSaveGLState {
   }
 
   public void saveCore() {
+  	// Store currently bound program.
     params.clear();
     gl.glGetIntegerv(gl.GL_CURRENT_PROGRAM(), params);
     currentProgram = params.get(0);
 
+    // Store currently active texture unit.
     params.clear();
     gl.glGetIntegerv(gl.GL_ACTIVE_TEXTURE(), params);
     activeTexture = params.get(0);
 
+    // This texture unit will be used by Nifty.
+    gl.glActiveTexture(gl.GL_TEXTURE0());
+
+    // Store sampler bound to it.
     params.clear();
     gl.glGetIntegerv(gl.GL_SAMPLER_BINDING(), params);
     samplerBindingTex0 = params.get(0);
+    
+    // Now unbind sampler so it doesn't overrides texture filtering.
+    gl.glBindSampler(0, 0);
 
+    // Store texture bound to 2D target.
     params.clear();
     gl.glGetIntegerv(gl.GL_TEXTURE_BINDING_2D(), params);
     textureBinding = params.get(0);
 
+    // Store blending state.
     blending = gl.glIsEnabled(gl.GL_BLEND());
 
+    // Store blending source parameter.
     params.clear();
     gl.glGetIntegerv(gl.GL_BLEND_SRC(), params);
     blendingSrcFactor = params.get(0);
 
+    // Store blending destination parameter.
     params.clear();
     gl.glGetIntegerv(gl.GL_BLEND_DST(), params);
     blendingDstFactor = params.get(0);
 
+    // Store primitive restart state.
     primitiveRestart = gl.glIsEnabled(gl.GL_PRIMITIVE_RESTART());
 
+    // Store primitive restart index.
     params.clear();
     gl.glGetIntegerv(gl.GL_PRIMITIVE_RESTART_INDEX(), params);
     primitiveRestartIndex = params.get(0);
@@ -71,14 +86,23 @@ public class CoreProfileSaveGLState {
   }
 
   public void restoreCore() {
+  	// Restore program.
     gl.glUseProgram(currentProgram);
-    gl.glActiveTexture(activeTexture);
+    // Restore sampler that was bound to texture unit 0.
     gl.glBindSampler(0, samplerBindingTex0);
+    // Restore active texture unit.
+    gl.glActiveTexture(activeTexture);
+    // Restore bound texture to 2D target.
     gl.glBindTexture(gl.GL_TEXTURE_2D(), textureBinding);
+    // Restore blending state.
     enable(gl.GL_BLEND(), blending);
+    // Restore blending functions.
     gl.glBlendFunc(blendingSrcFactor, blendingDstFactor);
+    // Restore primitive restart state.
     enable(gl.GL_PRIMITIVE_RESTART(), primitiveRestart);
+    // Restore primitive restart index.
     gl.glPrimitiveRestartIndex(primitiveRestartIndex);
+
     CheckGL.checkGLError(gl, "Failed to restore OpenGL Core Profile state!", true);
   }
 


### PR DESCRIPTION
Sampler state gets stored, then sampler gets unbound so it doesn't overrides per-texture filtering, then it gets restored.
