### PR TITLE
Modified ClassHelper so that the context classloader is used.

### DIFF
--- a/nifty-core/src/main/java/de/lessvoid/xml/tools/ClassHelper.java
+++ b/nifty-core/src/main/java/de/lessvoid/xml/tools/ClassHelper.java
@@ -29,7 +29,8 @@ public final class ClassHelper {
   @Nullable
   public static Class<?> loadClass(@Nonnull final String className) {
     try {
-      return Class.forName(className);
+		return Thread.currentThread().getContextClassLoader().loadClass(className);
+//      return Class.forName(className);
     } catch (Exception e) {
       log.warning("class [" + className + "] could not be found (" + e.getMessage() + ")");
     }
@@ -46,7 +47,8 @@ public final class ClassHelper {
   @Nullable
   public static <T> T getInstance(@Nonnull final String className, @Nonnull final Class<T> type) {
     try {
-	  Class<?> cls = Class.forName(className);
+		Class<?> cls = Thread.currentThread().getContextClassLoader().loadClass(className);
+//	  Class<?> cls = Class.forName(className);
 	  if (type.isAssignableFrom(cls)) {
 	    return type.cast(cls.newInstance());
 	  } else {


### PR DESCRIPTION
I'm using Nifty inside the netbeans platform. There, the 'normal' classloader can only load classes from dependencies.
This makes it impossible to register new ScreenControllers or effects via XML, they simply cannot be found.
This is fixed by using the context classloader instead which has access to all classes.
Outside the netbeans platform, the context classloader is just the normal classloader, so the functionality is also preserved in normal scenarios.
