### PR TITLE
Fixed WindowBuilder closeable method.

### DIFF
--- a/nifty-controls/src/main/java/de/lessvoid/nifty/controls/window/builder/WindowBuilder.java
+++ b/nifty-controls/src/main/java/de/lessvoid/nifty/controls/window/builder/WindowBuilder.java
@@ -15,6 +15,6 @@ public class WindowBuilder extends ControlBuilder {
   }
 
   public void closeable(final boolean closeable) {
-    set("closable", String.valueOf(closeable));
+    set("closeable", String.valueOf(closeable));
   }
 }


### PR DESCRIPTION
WindowBuilder closeable method is not working correctly.
It is because there is a misspelling in property setter.
