### PR TITLE
 Utility classes should not have public constructors

### DIFF
--- a/nifty-examples/src/main/java/de/lessvoid/nifty/examples/usecase/UseCaseRunner.java
+++ b/nifty-examples/src/main/java/de/lessvoid/nifty/examples/usecase/UseCaseRunner.java
@@ -61,6 +61,9 @@ public class UseCaseRunner {
     initAdapters.put("dummy", new UseCaseRunnerAdapterDummy());
   }
 
+  private UseCaseRunner() {
+  }
+
   static void run(final Class<?> useCaseClass, final String[] args) throws Exception {
     run(useCaseClass, args, new NiftyConfiguration());
   }

--- a/nifty-examples/src/main/java/de/lessvoid/nifty/examples/usecase/UseCase_a01_FullScreenColorNode.java
+++ b/nifty-examples/src/main/java/de/lessvoid/nifty/examples/usecase/UseCase_a01_FullScreenColorNode.java
@@ -44,6 +44,9 @@ public class UseCase_a01_FullScreenColorNode {
           .addNode(contentNode());
   }
 
+  private UseCase_a01_FullScreenColorNode() {
+  }
+
   public static void main(final String[] args) throws Exception {
     UseCaseRunner.run(UseCase_a01_FullScreenColorNode.class, args);
   }

--- a/nifty-examples/src/main/java/de/lessvoid/nifty/examples/usecase/UseCase_a02_QuarterRootNodeWithTwoHorizontalChildNodes.java
+++ b/nifty-examples/src/main/java/de/lessvoid/nifty/examples/usecase/UseCase_a02_QuarterRootNodeWithTwoHorizontalChildNodes.java
@@ -62,6 +62,9 @@ public class UseCase_a02_QuarterRootNodeWithTwoHorizontalChildNodes {
                     .addNode(contentNode());
   }
 
+  private UseCase_a02_QuarterRootNodeWithTwoHorizontalChildNodes() {
+  }
+
   public static void main(final String[] args) throws Exception {
     UseCaseRunner.run(UseCase_a02_QuarterRootNodeWithTwoHorizontalChildNodes.class, args);
   }

--- a/nifty-examples/src/main/java/de/lessvoid/nifty/examples/usecase/UseCase_a03_FixedSizedRootNode.java
+++ b/nifty-examples/src/main/java/de/lessvoid/nifty/examples/usecase/UseCase_a03_FixedSizedRootNode.java
@@ -51,6 +51,9 @@ public class UseCase_a03_FixedSizedRootNode {
               .addNode(contentNode());
   }
 
+  private UseCase_a03_FixedSizedRootNode() {
+  }
+
   public static void main(final String[] args) throws Exception {
     UseCaseRunner.run(UseCase_a03_FixedSizedRootNode.class, args);
   }

--- a/nifty-examples/src/main/java/de/lessvoid/nifty/examples/usecase/UseCase_a04_RotatingRootNode.java
+++ b/nifty-examples/src/main/java/de/lessvoid/nifty/examples/usecase/UseCase_a04_RotatingRootNode.java
@@ -64,6 +64,9 @@ public class UseCase_a04_RotatingRootNode {
                   .addNode(contentNode());
   }
 
+  private UseCase_a04_RotatingRootNode() {
+  }
+
   public static void main(final String[] args) throws Exception {
     UseCaseRunner.run(UseCase_a04_RotatingRootNode.class, args, new NiftyConfiguration().clearScreen(true));
   }

--- a/nifty-examples/src/main/java/de/lessvoid/nifty/examples/usecase/UseCase_a05_RotatingChildNode.java
+++ b/nifty-examples/src/main/java/de/lessvoid/nifty/examples/usecase/UseCase_a05_RotatingChildNode.java
@@ -111,6 +111,9 @@ public class UseCase_a05_RotatingChildNode {
     });
   }
 
+  private UseCase_a05_RotatingChildNode() {
+  }
+
   public static void main(final String[] args) throws Exception {
     UseCaseRunner.run(
         UseCase_a05_RotatingChildNode.class,

--- a/nifty-examples/src/main/java/de/lessvoid/nifty/examples/usecase/UseCase_a07_GroupedTransformation.java
+++ b/nifty-examples/src/main/java/de/lessvoid/nifty/examples/usecase/UseCase_a07_GroupedTransformation.java
@@ -94,6 +94,9 @@ public class UseCase_a07_GroupedTransformation {
     });
   }
 
+  private UseCase_a07_GroupedTransformation() {
+  }
+
   public static void main(final String[] args) throws Exception {
     UseCaseRunner.run(UseCase_a07_GroupedTransformation.class, args, new NiftyConfiguration().clearScreen(true));
   }

--- a/nifty-examples/src/main/java/de/lessvoid/nifty/examples/usecase/UseCase_b02_CanvasLinearGradient.java
+++ b/nifty-examples/src/main/java/de/lessvoid/nifty/examples/usecase/UseCase_b02_CanvasLinearGradient.java
@@ -82,6 +82,9 @@ public class UseCase_b02_CanvasLinearGradient {
 
   }
 
+  private UseCase_b02_CanvasLinearGradient() {
+  }
+
   public static void main(final String[] args) throws Exception {
     UseCaseRunner.run(UseCase_b02_CanvasLinearGradient.class, args);
   }

--- a/nifty-examples/src/main/java/de/lessvoid/nifty/examples/usecase/UseCase_b03_CanvasText.java
+++ b/nifty-examples/src/main/java/de/lessvoid/nifty/examples/usecase/UseCase_b03_CanvasText.java
@@ -84,6 +84,9 @@ public class UseCase_b03_CanvasText {
         }));
   }
 
+  private UseCase_b03_CanvasText() {
+  }
+
   public static void main(final String[] args) throws Exception {
     UseCaseRunner.run(UseCase_b03_CanvasText.class, args);
   }

--- a/nifty-examples/src/main/java/de/lessvoid/nifty/examples/usecase/UseCase_b04_CanvasImage.java
+++ b/nifty-examples/src/main/java/de/lessvoid/nifty/examples/usecase/UseCase_b04_CanvasImage.java
@@ -60,7 +60,10 @@ public class UseCase_b04_CanvasImage {
         canvas.drawImage(image, 10, 10);
       }
     }));
-  }  
+  }
+
+  private UseCase_b04_CanvasImage() {
+  }
 
   public static void main(final String[] args) throws Exception {
     UseCaseRunner.run(UseCase_b04_CanvasImage.class, args);

--- a/nifty-examples/src/main/java/de/lessvoid/nifty/examples/usecase/UseCase_b05_CanvasCustomShader.java
+++ b/nifty-examples/src/main/java/de/lessvoid/nifty/examples/usecase/UseCase_b05_CanvasCustomShader.java
@@ -52,6 +52,9 @@ public class UseCase_b05_CanvasCustomShader {
     });
   }
 
+  private UseCase_b05_CanvasCustomShader() {
+  }
+
   public static void main(final String[] args) throws Exception {
     UseCaseRunner.run(UseCase_b05_CanvasCustomShader.class, args);
   }

--- a/nifty-examples/src/main/java/de/lessvoid/nifty/examples/usecase/UseCase_b06_CanvasTransformScale.java
+++ b/nifty-examples/src/main/java/de/lessvoid/nifty/examples/usecase/UseCase_b06_CanvasTransformScale.java
@@ -67,7 +67,10 @@ public class UseCase_b06_CanvasTransformScale {
             }));
   }
 
-  public static void main(final String[] args) throws Exception {
+    private UseCase_b06_CanvasTransformScale() {
+    }
+
+    public static void main(final String[] args) throws Exception {
     UseCaseRunner.run(UseCase_b06_CanvasTransformScale.class, args);
   }
 }

--- a/nifty-examples/src/main/java/de/lessvoid/nifty/examples/usecase/UseCase_b07_CanvasTransformTranslate.java
+++ b/nifty-examples/src/main/java/de/lessvoid/nifty/examples/usecase/UseCase_b07_CanvasTransformTranslate.java
@@ -67,7 +67,10 @@ public class UseCase_b07_CanvasTransformTranslate {
             }));
   }
 
-  public static void main(final String[] args) throws Exception {
+    private UseCase_b07_CanvasTransformTranslate() {
+    }
+
+    public static void main(final String[] args) throws Exception {
     UseCaseRunner.run(UseCase_b07_CanvasTransformTranslate.class, args);
   }
 }

--- a/nifty-examples/src/main/java/de/lessvoid/nifty/examples/usecase/UseCase_b08_CanvasTransformRotate.java
+++ b/nifty-examples/src/main/java/de/lessvoid/nifty/examples/usecase/UseCase_b08_CanvasTransformRotate.java
@@ -67,7 +67,10 @@ public class UseCase_b08_CanvasTransformRotate {
             }));
   }
 
-  public static void main(final String[] args) throws Exception {
+    private UseCase_b08_CanvasTransformRotate() {
+    }
+
+    public static void main(final String[] args) throws Exception {
     UseCaseRunner.run(UseCase_b08_CanvasTransformRotate.class, args);
   }
 }

--- a/nifty-examples/src/main/java/de/lessvoid/nifty/examples/usecase/UseCase_b09_CanvasTransformReset.java
+++ b/nifty-examples/src/main/java/de/lessvoid/nifty/examples/usecase/UseCase_b09_CanvasTransformReset.java
@@ -73,7 +73,10 @@ public class UseCase_b09_CanvasTransformReset {
             }));
   }
 
-  public static void main(final String[] args) throws Exception {
+    private UseCase_b09_CanvasTransformReset() {
+    }
+
+    public static void main(final String[] args) throws Exception {
     UseCaseRunner.run(UseCase_b09_CanvasTransformReset.class, args);
   }
 }

--- a/nifty-examples/src/main/java/de/lessvoid/nifty/examples/usecase/UseCase_b11_CanvasLines.java
+++ b/nifty-examples/src/main/java/de/lessvoid/nifty/examples/usecase/UseCase_b11_CanvasLines.java
@@ -109,6 +109,9 @@ public class UseCase_b11_CanvasLines {
     });
   }
 
+  private UseCase_b11_CanvasLines() {
+  }
+
   public static void main(final String[] args) throws Exception {
     UseCaseRunner.run(UseCase_b11_CanvasLines.class, args);
   }

--- a/nifty-examples/src/main/java/de/lessvoid/nifty/examples/usecase/UseCase_b16_CanvasFillPath.java
+++ b/nifty-examples/src/main/java/de/lessvoid/nifty/examples/usecase/UseCase_b16_CanvasFillPath.java
@@ -75,6 +75,9 @@ public class UseCase_b16_CanvasFillPath {
     });
   }
 
+  private UseCase_b16_CanvasFillPath() {
+  }
+
   public static void main(final String[] args) throws Exception {
     UseCaseRunner.run(UseCase_b16_CanvasFillPath.class, args);
   }

--- a/nifty-examples/src/main/java/de/lessvoid/nifty/examples/usecase/UseCase_b17_CanvasArcTo.java
+++ b/nifty-examples/src/main/java/de/lessvoid/nifty/examples/usecase/UseCase_b17_CanvasArcTo.java
@@ -81,6 +81,9 @@ public class UseCase_b17_CanvasArcTo {
     });
   }
 
+  private UseCase_b17_CanvasArcTo() {
+  }
+
   public static void main(final String[] args) throws Exception {
     de.lessvoid.nifty.examples.usecase.UseCaseRunner.run(UseCase_b17_CanvasArcTo.class, args);
   }

--- a/nifty-examples/src/main/java/de/lessvoid/nifty/examples/usecase/UseCase_c10_ButtonBasic.java
+++ b/nifty-examples/src/main/java/de/lessvoid/nifty/examples/usecase/UseCase_c10_ButtonBasic.java
@@ -69,6 +69,9 @@ public class UseCase_c10_ButtonBasic {
                 .addNode(button);
   }
 
+  private UseCase_c10_ButtonBasic() {
+  }
+
   public static void main(final String[] args) throws Exception {
     UseCaseRunner.run(UseCase_c10_ButtonBasic.class, args);
   }

--- a/nifty-examples/src/main/java/de/lessvoid/nifty/examples/usecase/UseCase_l01_DockLayoutSimple.java
+++ b/nifty-examples/src/main/java/de/lessvoid/nifty/examples/usecase/UseCase_l01_DockLayoutSimple.java
@@ -82,6 +82,9 @@ public class UseCase_l01_DockLayoutSimple {
                   .addNode(contentNode());
   }
 
+  private UseCase_l01_DockLayoutSimple() {
+  }
+
   public static void main(final String[] args) throws Exception {
     UseCaseRunner.run(UseCase_l01_DockLayoutSimple.class, args);
   }

--- a/nifty-examples/src/main/java/de/lessvoid/nifty/examples/usecase/UseCase_l02_DockLayoutSnake.java
+++ b/nifty-examples/src/main/java/de/lessvoid/nifty/examples/usecase/UseCase_l02_DockLayoutSnake.java
@@ -115,6 +115,9 @@ public final class UseCase_l02_DockLayoutSnake {
     }
   }
 
+  private UseCase_l02_DockLayoutSnake() {
+  }
+
   public static void main(final String[] args) throws Exception {
     UseCaseRunner.run(UseCase_l02_DockLayoutSnake.class, args);
   }

--- a/nifty-examples/src/main/java/de/lessvoid/nifty/examples/usecase/UseCase_l03_DockLayoutCenter.java
+++ b/nifty-examples/src/main/java/de/lessvoid/nifty/examples/usecase/UseCase_l03_DockLayoutCenter.java
@@ -87,6 +87,9 @@ public class UseCase_l03_DockLayoutCenter {
                 .addNode(contentNode());
   }
 
+  private UseCase_l03_DockLayoutCenter() {
+  }
+
   public static void main(final String[] args) throws Exception {
     UseCaseRunner.run(UseCase_l03_DockLayoutCenter.class, args);
   }

--- a/nifty-examples/src/main/java/de/lessvoid/nifty/examples/usecase/UseCase_l04_AlignmentLayoutCenter.java
+++ b/nifty-examples/src/main/java/de/lessvoid/nifty/examples/usecase/UseCase_l04_AlignmentLayoutCenter.java
@@ -54,6 +54,9 @@ public final class UseCase_l04_AlignmentLayoutCenter {
                 .addNode(contentNode());
   }
 
+  private UseCase_l04_AlignmentLayoutCenter() {
+  }
+
   public static void main(final String[] args) throws Exception {
     UseCaseRunner.run(UseCase_l04_AlignmentLayoutCenter.class, args);
   }

--- a/nifty-examples/src/main/java/de/lessvoid/nifty/examples/usecase/UseCase_l05_AlignmentLayoutCorners.java
+++ b/nifty-examples/src/main/java/de/lessvoid/nifty/examples/usecase/UseCase_l05_AlignmentLayoutCorners.java
@@ -79,6 +79,9 @@ public final class UseCase_l05_AlignmentLayoutCorners {
                   .addNode(contentNode());
   }
 
+  private UseCase_l05_AlignmentLayoutCorners() {
+  }
+
   public static void main(final String[] args) throws Exception {
     UseCaseRunner.run(UseCase_l05_AlignmentLayoutCorners.class, args);
   }

--- a/nifty-examples/src/main/java/de/lessvoid/nifty/examples/usecase/UseCase_l06_AlignmentLayoutStretching.java
+++ b/nifty-examples/src/main/java/de/lessvoid/nifty/examples/usecase/UseCase_l06_AlignmentLayoutStretching.java
@@ -97,6 +97,9 @@ public final class UseCase_l06_AlignmentLayoutStretching {
                   .addNode(contentNode());
   }
 
+  private UseCase_l06_AlignmentLayoutStretching() {
+  }
+
   public static void main(final String[] args) throws Exception {
     UseCaseRunner.run(UseCase_l06_AlignmentLayoutStretching.class, args);
   }

--- a/nifty-examples/src/main/java/de/lessvoid/nifty/examples/usecase/UseCase_z00_DeviantArtViewer.java
+++ b/nifty-examples/src/main/java/de/lessvoid/nifty/examples/usecase/UseCase_z00_DeviantArtViewer.java
@@ -86,6 +86,9 @@ public class UseCase_z00_DeviantArtViewer {
     });
   }
 
+  private UseCase_z00_DeviantArtViewer() {
+  }
+
   public static void main(final String[] args) throws Exception {
     UseCaseRunner.run(UseCase_z00_DeviantArtViewer.class, args,
       new NiftyConfiguration()

--- a/nifty/src/main/java/de/lessvoid/niftyinternal/common/IdGenerator.java
+++ b/nifty/src/main/java/de/lessvoid/niftyinternal/common/IdGenerator.java
@@ -31,6 +31,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class IdGenerator {
   private static final AtomicInteger id = new AtomicInteger(1);
 
+  private IdGenerator() {
+  }
+
   public static int generate() {
     return id.incrementAndGet();
   }

--- a/nifty/src/main/java/de/lessvoid/niftyinternal/common/ListBuilder.java
+++ b/nifty/src/main/java/de/lessvoid/niftyinternal/common/ListBuilder.java
@@ -5,6 +5,9 @@ import java.util.List;
 
 public class ListBuilder {
 
+  private ListBuilder() {
+  }
+
   /**
    * Make a comma separated String from the list of given Strings.
    * @param values the values to convert into a comma separated String

--- a/nifty/src/main/java/de/lessvoid/niftyinternal/math/MatrixFactory.java
+++ b/nifty/src/main/java/de/lessvoid/niftyinternal/math/MatrixFactory.java
@@ -33,6 +33,9 @@ package de.lessvoid.niftyinternal.math;
  */
 public class MatrixFactory {
 
+  private MatrixFactory() {
+  }
+
   /**
    * Create orthographic projection Matrix4f.
    * @param width width

--- a/nifty/src/main/java/de/lessvoid/niftyinternal/render/io/ImageLoaderFactory.java
+++ b/nifty/src/main/java/de/lessvoid/niftyinternal/render/io/ImageLoaderFactory.java
@@ -6,6 +6,9 @@ import javax.annotation.Nonnull;
  * @author Aaron Mahan &lt;aaron@forerunnergames.com&gt;
  */
 public class ImageLoaderFactory {
+  private ImageLoaderFactory() {
+  }
+
   public static ImageLoader createImageLoader(@Nonnull final String imageFilename) {
     return imageFilename.endsWith(".tga") ? new ImageLoaderTGA() : new ImageLoaderImageIO();
   }

--- a/nifty/src/main/java/self/philbrown/cssparser/Tester.java
+++ b/nifty/src/main/java/self/philbrown/cssparser/Tester.java
@@ -28,6 +28,9 @@ import java.text.ParseException;
  */
 public class Tester 
 {
+	private Tester() {
+	}
+
 	/**
 	 * Run the test case
 	 * @param args

--- a/nifty/src/test/java/de/lessvoid/nifty/AssertColor.java
+++ b/nifty/src/test/java/de/lessvoid/nifty/AssertColor.java
@@ -34,6 +34,9 @@ import static org.junit.Assert.assertEquals;
 public class AssertColor {
   private static final float DELTA = 1.f / 255.f;
 
+  private AssertColor() {
+  }
+
   public static void assertColor(final double r, final double g, final double b, final double a, final NiftyColor c) {
     assertEquals(r, c.getRed(), DELTA);
     assertEquals(g, c.getGreen(), DELTA);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - “Utility classes should not have public constructors ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
Ayman Abdelghany.
