### PR TITLE
equals(Object obj)" and "hashCode()" should be overridden in pairs

### DIFF
--- a/nifty/src/main/java/de/lessvoid/nifty/UnitValue.java
+++ b/nifty/src/main/java/de/lessvoid/nifty/UnitValue.java
@@ -228,6 +228,16 @@ public class UnitValue {
     return false;
   }
 
+  @Override
+  public int hashCode() {
+    int result = this.value != null ? this.value.hashCode() : 0;
+    result = 31 * result + (this.percentValue != +0.0f ? Float.floatToIntBits(this.percentValue) : 0);
+    result = 31 * result + (this.pixelValue != +0.0f ? Float.floatToIntBits(this.pixelValue) : 0);
+    result = 31 * result + (this.hasWidthSuffix ? 1 : 0);
+    result = 31 * result + (this.hasHeightSuffix ? 1 : 0);
+    return result;
+  }
+
   /**
    * Get the percent value this value represent.
    * @return the actual percent value.

--- a/nifty/src/main/java/self/philbrown/cssparser/Token.java
+++ b/nifty/src/main/java/self/philbrown/cssparser/Token.java
@@ -178,7 +178,14 @@ public class Token implements ParserConstants
 		}
 		return false;
 	}
-	
+
+	@Override
+	public int hashCode() {
+		int result = this.tokenCode;
+		result = 31 * result + (this.attribute != null ? this.attribute.hashCode() : 0);
+		return result;
+	}
+
 	/**
 	 * Not-Equals shortcut method
 	 * @param o

--- a/nifty/src/main/java/self/philbrown/cssparser/TokenSequence.java
+++ b/nifty/src/main/java/self/philbrown/cssparser/TokenSequence.java
@@ -199,7 +199,14 @@ public class TokenSequence implements Iterable<Token>
 		}
 		return false;
 	}
-	
+
+	@Override
+	public int hashCode() {
+		int result = this.tokens != null ? this.tokens.hashCode() : 0;
+		result = 31 * result + (this.string != null ? this.string.hashCode() : 0);
+		return result;
+	}
+
 	/**
 	 * Not Equals
 	 * @param o


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1206 - “equals(Object obj)" and "hashCode()" should be overridden in pairs ”. You can find more information about the issue here: https://dev.eclipse.org/sonar/rules/show/squid:S1206
Please let me know if you have any questions.
Ayman Abdelghany.
