### PR TITLE
Null pointers should not be dereferenced

### DIFF
--- a/nifty/src/main/java/de/lessvoid/niftyinternal/common/NiftyServiceLoader.java
+++ b/nifty/src/main/java/de/lessvoid/niftyinternal/common/NiftyServiceLoader.java
@@ -39,7 +39,7 @@ public final class NiftyServiceLoader<S> implements Iterable<S> {
     }
 
     Map<String, S> providers = new HashMap<>();
-    while (configs.hasMoreElements()) {
+    while (configs != null && configs.hasMoreElements()) {
       URL nextURL = configs.nextElement();
 
       for (String configLine : parse(service, nextURL)) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2259 - “Null pointers should not be dereferenced”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2259
Please let me know if you have any questions.
Ayman Abdelghany.
