### PR TITLE
Simplify the generics declaration by using the diamond operator ("<>") to reduce the verbosity of generics code.

### DIFF
--- a/nifty-input-lwjgl/src/main/java/de/lessvoid/nifty/input/lwjgl/NiftyInputDeviceLWJGL.java
+++ b/nifty-input-lwjgl/src/main/java/de/lessvoid/nifty/input/lwjgl/NiftyInputDeviceLWJGL.java
@@ -55,8 +55,8 @@ public class NiftyInputDeviceLWJGL implements NiftyInputDevice {
   private final NiftyKeyboardInputEventFactory keyboardEventCreator = new NiftyKeyboardInputEventFactory();
   private final IntBuffer viewportBuffer = BufferUtils.createIntBuffer(4 * 4);
   @Nonnull
-  private final ConcurrentLinkedQueue<MouseInputEvent> mouseEventsOut = new ConcurrentLinkedQueue<MouseInputEvent>();
-  private final ConcurrentLinkedQueue<NiftyKeyboardEvent> keyboardEventsOut = new ConcurrentLinkedQueue<NiftyKeyboardEvent>();
+  private final ConcurrentLinkedQueue<MouseInputEvent> mouseEventsOut = new ConcurrentLinkedQueue<>();
+  private final ConcurrentLinkedQueue<NiftyKeyboardEvent> keyboardEventsOut = new ConcurrentLinkedQueue<>();
 
   private boolean niftyHasKeyboardFocus = true;
   private boolean niftyTakesKeyboardFocusOnClick = false;

--- a/nifty/src/main/java/de/lessvoid/niftyinternal/InternalNiftyEventBus.java
+++ b/nifty/src/main/java/de/lessvoid/niftyinternal/InternalNiftyEventBus.java
@@ -34,7 +34,7 @@ public class InternalNiftyEventBus {
   private MBassador<NiftyEvent> eventBus;
 
   public InternalNiftyEventBus() {
-    eventBus = new MBassador<NiftyEvent>(BusConfiguration.SyncAsync());
+    eventBus = new MBassador<>(BusConfiguration.SyncAsync());
   }
 
   public void subscribe(final Object listener) {

--- a/nifty/src/main/java/de/lessvoid/niftyinternal/NiftyResourceLoader.java
+++ b/nifty/src/main/java/de/lessvoid/niftyinternal/NiftyResourceLoader.java
@@ -54,7 +54,7 @@ public class NiftyResourceLoader {
   private final List<NiftyResourceLocation> locations;
 
   public NiftyResourceLoader() {
-    locations = new ArrayList<NiftyResourceLocation>();
+    locations = new ArrayList<>();
     locations.add(new ClasspathLocation());
     locations.add(new FileSystemLocation(new File(".")));
   }

--- a/nifty/src/main/java/de/lessvoid/niftyinternal/render/batch/BatchManager.java
+++ b/nifty/src/main/java/de/lessvoid/niftyinternal/render/batch/BatchManager.java
@@ -41,7 +41,7 @@ import de.lessvoid.nifty.spi.NiftyTexture;
 import javax.annotation.Nonnull;
 
 public class BatchManager {
-  private List<Batch<?>> activeBatches = new ArrayList<Batch<?>>();
+  private List<Batch<?>> activeBatches = new ArrayList<>();
 
   public void begin() {
     activeBatches.clear();

--- a/nifty/src/main/java/de/lessvoid/niftyinternal/render/font/FontRenderer.java
+++ b/nifty/src/main/java/de/lessvoid/niftyinternal/render/font/FontRenderer.java
@@ -47,7 +47,7 @@ import de.lessvoid.nifty.spi.NiftyRenderDevice.PreMultipliedAlphaMode;
 import de.lessvoid.nifty.spi.NiftyTexture;
 
 public class FontRenderer implements JGLFontRenderer {
-  private final Map<String, BitmapInfo> textureInfos = new HashMap<String, BitmapInfo>();
+  private final Map<String, BitmapInfo> textureInfos = new HashMap<>();
   private final ColorValueParser colorValueParser = new ColorValueParser();
   private final NiftyRenderDevice renderDevice;
   private final NiftyMutableColor textColor = new NiftyMutableColor(NiftyColor.white());
@@ -216,7 +216,7 @@ public class FontRenderer implements JGLFontRenderer {
   // BitmapInfo
   class BitmapInfo {
     private final NiftyTexture image;
-    private final Map<Integer, CharRenderInfo> characterIndices = new HashMap<Integer, CharRenderInfo>();
+    private final Map<Integer, CharRenderInfo> characterIndices = new HashMap<>();
 
     public BitmapInfo(final NiftyTexture image) {
       this.image = image;

--- a/nifty/src/main/java/de/lessvoid/niftyinternal/style/specialparser/LinearGradientParser.java
+++ b/nifty/src/main/java/de/lessvoid/niftyinternal/style/specialparser/LinearGradientParser.java
@@ -96,7 +96,7 @@ public class LinearGradientParser {
   private static final String UNIT_RAD = "rad";
   private static final String UNIT_TURN = "turn";
 
-  private static final Map<String, String> toSideOrCornerMap = new HashMap<String, String>();
+  private static final Map<String, String> toSideOrCornerMap = new HashMap<>();
 
   static {
     toSideOrCornerMap.put(TOP,          "0");
@@ -173,7 +173,7 @@ public class LinearGradientParser {
 
   public static class Result {
     private double angleInRadiants;
-    private List<ColorStop> colorStops = new ArrayList<ColorStop>();
+    private List<ColorStop> colorStops = new ArrayList<>();
 
     public Result(final double angle) {
       this.angleInRadiants = angle;
@@ -193,7 +193,7 @@ public class LinearGradientParser {
   }
 
   public Result parse(final String value) throws Exception {
-    Queue<Token> tokenSeq = new LinkedList<Token>(TokenSequence.parse(value).getTokens());
+    Queue<Token> tokenSeq = new LinkedList<>(TokenSequence.parse(value).getTokens());
     assertIdentifier(tokenSeq, "linear-gradient");
     assertLeftParenthesis(tokenSeq);
 
@@ -257,11 +257,11 @@ public class LinearGradientParser {
     if (first.tokenCode != Token.IDENTIFIER) {
       throw new Exception("expected identifier token after 'to' but was (" + first.toDebugString() + ")");
     }
-    Set<String> supportedSidesH = new TreeSet<String>();
+    Set<String> supportedSidesH = new TreeSet<>();
     supportedSidesH.add(LEFT);
     supportedSidesH.add(RIGHT);
 
-    Set<String> supportedSidesV = new TreeSet<String>();
+    Set<String> supportedSidesV = new TreeSet<>();
     supportedSidesV.add(TOP);
     supportedSidesV.add(BOTTOM);
 
@@ -314,7 +314,7 @@ public class LinearGradientParser {
     if (next.tokenCode != Token.IDENTIFIER) {
       throw new Exception("expected angle unit identifier here but was (" + next.toDebugString() + ")");
     }
-    Set<String> supportedUnits = new HashSet<String>();
+    Set<String> supportedUnits = new HashSet<>();
     supportedUnits.add(UNIT_DEG);
     supportedUnits.add(UNIT_GRAD);
     supportedUnits.add(UNIT_RAD);

--- a/nifty/src/main/java/de/lessvoid/niftyinternal/style/specialparser/PseudoClassExtractor.java
+++ b/nifty/src/main/java/de/lessvoid/niftyinternal/style/specialparser/PseudoClassExtractor.java
@@ -36,7 +36,7 @@ import java.util.Set;
 import self.philbrown.cssparser.Token;
 
 public class PseudoClassExtractor {
-  private final static Set<Integer> PSEUDO_CLASSES = new HashSet<Integer>();
+  private final static Set<Integer> PSEUDO_CLASSES = new HashSet<>();
   {
     PSEUDO_CLASSES.add(Token.HOVER);
     PSEUDO_CLASSES.add(Token.ACTIVE);
@@ -47,9 +47,9 @@ public class PseudoClassExtractor {
   }
 
   public List<String> parse(final List<Token> tokenList) {
-    List<String> result = new ArrayList<String>();
+    List<String> result = new ArrayList<>();
 
-    Queue<Token> tokenSeq = new LinkedList<Token>(tokenList);
+    Queue<Token> tokenSeq = new LinkedList<>(tokenList);
     while (tokenSeq.peek() != null) {
       Token colon = scanToColon(tokenSeq);
       if (colon != null) {
@@ -65,7 +65,7 @@ public class PseudoClassExtractor {
 
   public String extractSelector(final List<Token> tokenList) {
     StringBuilder result = new StringBuilder();
-    Queue<Token> tokenSeq = new LinkedList<Token>(tokenList);
+    Queue<Token> tokenSeq = new LinkedList<>(tokenList);
     while (tokenSeq.peek() != null) {
       Token next = tokenSeq.poll();
       while (next != null && next.tokenCode != Token.COLON) {

--- a/nifty/src/main/java/self/philbrown/cssparser/CSSParser.java
+++ b/nifty/src/main/java/self/philbrown/cssparser/CSSParser.java
@@ -209,7 +209,7 @@ public class CSSParser implements ParserConstants
 					match(IDENTIFIER);
 					match(LEFT_CURLY_BRACKET);
 					int curlies = 1;
-					List<KeyFrame> keyFrames = new ArrayList<KeyFrame>();
+					List<KeyFrame> keyFrames = new ArrayList<>();
 					while (curlies > 0)
 					{
 						if (t.tokenCode == LEFT_CURLY_BRACKET)
@@ -246,7 +246,7 @@ public class CSSParser implements ParserConstants
 							}
 							match(LEFT_CURLY_BRACKET);
 							
-							List<Declaration> declarations = new ArrayList<Declaration>();
+							List<Declaration> declarations = new ArrayList<>();
 							while (t.tokenCode != RIGHT_CURLY_BRACKET)
 							{
 								TokenSequence.Builder property = new TokenSequence.Builder();
@@ -278,7 +278,7 @@ public class CSSParser implements ParserConstants
 					//get Typeface from handler
 					match(AT_RULE);
 					match(LEFT_CURLY_BRACKET);
-					List<Declaration> declarations = new ArrayList<Declaration>();
+					List<Declaration> declarations = new ArrayList<>();
 					while(t.tokenCode != RIGHT_CURLY_BRACKET)
 					{
 						TokenSequence.Builder property = new TokenSequence.Builder();
@@ -377,7 +377,7 @@ public class CSSParser implements ParserConstants
 					}
 					match(LEFT_CURLY_BRACKET);
 					
-					List<Declaration> declarations = new ArrayList<Declaration>();
+					List<Declaration> declarations = new ArrayList<>();
 					while (t.tokenCode != RIGHT_CURLY_BRACKET)
 					{
 						TokenSequence.Builder property = new TokenSequence.Builder();
@@ -478,7 +478,7 @@ public class CSSParser implements ParserConstants
 					return;
 				}
 				match(LEFT_CURLY_BRACKET);
-				List<Declaration> declarations = new ArrayList<Declaration>();
+				List<Declaration> declarations = new ArrayList<>();
 				while(t.tokenCode != RIGHT_CURLY_BRACKET)
 				{
 					TokenSequence.Builder property = new TokenSequence.Builder();

--- a/nifty/src/main/java/self/philbrown/cssparser/FontFace.java
+++ b/nifty/src/main/java/self/philbrown/cssparser/FontFace.java
@@ -140,7 +140,7 @@ public class FontFace implements ParserConstants
 				fontFamily = property;
 			else if (property.equals("src"))
 			{
-				sources = new HashMap<String, List<String>>();
+				sources = new HashMap<>();
 				List<Token> tokens = value.getTokens();
 				Iterator<Token> iterator = tokens.iterator();
 				while (iterator.hasNext())
@@ -161,7 +161,7 @@ public class FontFace implements ParserConstants
 						}
 						List<String> resources = sources.get(function);
 						if (resources == null)
-							resources = new ArrayList<String>();
+							resources = new ArrayList<>();
 						resources.add(uri.toString());
 						sources.put(function, resources);
 					}

--- a/nifty/src/main/java/self/philbrown/cssparser/KeyFrame.java
+++ b/nifty/src/main/java/self/philbrown/cssparser/KeyFrame.java
@@ -38,7 +38,7 @@ public class KeyFrame {
 	 */
 	public KeyFrame()
 	{
-		declarationBlock = new ArrayList<Declaration>();
+		declarationBlock = new ArrayList<>();
 	}
 	/**
 	 * Constructor

--- a/nifty/src/main/java/self/philbrown/cssparser/RuleSet.java
+++ b/nifty/src/main/java/self/philbrown/cssparser/RuleSet.java
@@ -38,7 +38,7 @@ public class RuleSet
 	 */
 	public RuleSet()
 	{
-		declarationBlock = new ArrayList<Declaration>();
+		declarationBlock = new ArrayList<>();
 	}
 	
 	/**

--- a/nifty/src/main/java/self/philbrown/cssparser/Scanner.java
+++ b/nifty/src/main/java/self/philbrown/cssparser/Scanner.java
@@ -50,9 +50,9 @@ public class Scanner implements ParserConstants
 	private int line = 1;
 	
 	/** Keeps track of imports so no redundant calls are made */
-	private List<String> imports = new ArrayList<String>();
+	private List<String> imports = new ArrayList<>();
 	/** Keeps track of supports statements so no redundant calls are made */
-	private List<String> supports = new ArrayList<String>();
+	private List<String> supports = new ArrayList<>();
 	
 	/** The input stream */
 	private InputStream is;

--- a/nifty/src/main/java/self/philbrown/cssparser/SequentialInputStream.java
+++ b/nifty/src/main/java/self/philbrown/cssparser/SequentialInputStream.java
@@ -22,7 +22,7 @@ public class SequentialInputStream extends InputStream
 
     public SequentialInputStream(InputStream... streams) throws IOException
     {
-        this.streams = new ArrayList<InputStream>();
+        this.streams = new ArrayList<>();
         for (InputStream stream : streams)
         {
         	this.streams.add(stream);

--- a/nifty/src/main/java/self/philbrown/cssparser/TokenSequence.java
+++ b/nifty/src/main/java/self/philbrown/cssparser/TokenSequence.java
@@ -55,7 +55,7 @@ public class TokenSequence implements Iterable<Token>
 	 */
 	public TokenSequence(Token token, String string)
 	{
-		this.tokens = new ArrayList<Token>();
+		this.tokens = new ArrayList<>();
 		this.tokens.add(token);
 		this.string = string;
 	}
@@ -103,7 +103,7 @@ public class TokenSequence implements Iterable<Token>
 	 */
 	public Enumeration<Token> enumerate()
 	{
-		Vector<Token> vector = new Vector<Token>();
+		Vector<Token> vector = new Vector<>();
 		for (int i = 0; i < tokens.size(); i++)
 		{
 			vector.add(tokens.get(i));
@@ -248,7 +248,7 @@ System.out.println("subSequence(0," + seq.length() + " = " + sub);//TODO remove 
 	 */
 	public TokenSequence[] splitOnAny(Token[] t)
 	{
-		List<TokenSequence> list = new ArrayList<TokenSequence>();
+		List<TokenSequence> list = new ArrayList<>();
 		Builder b = new Builder();
 		for (int i = 0; i < length(); i++)
 		{
@@ -283,7 +283,7 @@ System.out.println("subSequence(0," + seq.length() + " = " + sub);//TODO remove 
 	 */
 	public TokenSequence[] split(Token t)
 	{
-		List<TokenSequence> list = new ArrayList<TokenSequence>();
+		List<TokenSequence> list = new ArrayList<>();
 		Builder b = new Builder();
 		for (int i = 0; i < length(); i++)
 		{
@@ -365,7 +365,7 @@ System.out.println("subSequence(0," + seq.length() + " = " + sub);//TODO remove 
 		 */
 		public Builder()
 		{
-			tokens = new ArrayList<Token>();
+			tokens = new ArrayList<>();
 			builder = new StringBuilder();
 		}
 		


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2293 - “The diamond operator ("<>") should be used ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2293
Please let me know if you have any questions.
Ayman Abdelghany.
