### PR TITLE
Simpler Element building

### DIFF
--- a/nifty-core/src/main/java/de/lessvoid/nifty/builder/ElementBuilder.java
+++ b/nifty-core/src/main/java/de/lessvoid/nifty/builder/ElementBuilder.java
@@ -489,9 +489,9 @@ public abstract class ElementBuilder {
    *
    * @return the element created
    */
-  public Element build(@Nonnull final Nifty nifty, @Nonnull final Screen screen, @Nonnull final Element parent) {
+  public Element build(@Nonnull final Element parent) {
     ElementType type = buildElementType();
-    Element result = nifty.createElementFromType(screen, parent, type);
+    Element result = parent.getNifty().createElementFromType(parent.getScreen(), parent, type);
     parent.layoutElements();
     return result;
   }
@@ -502,13 +502,10 @@ public abstract class ElementBuilder {
    * @return the Element created
    */
   @Nonnull
-  public Element build(
-      @Nonnull final Nifty nifty,
-      @Nonnull final Screen screen,
-      @Nonnull final Element parent,
-      final int index) {
+  public Element build(@Nonnull final Element parent, final int index) {
+    Screen screen = parent.getScreen();
     ElementType type = buildElementType();
-    Element result = nifty.createElementFromType(screen, parent, type, index);
+    Element result = parent.getNifty().createElementFromType(screen, parent, type, index);
     screen.layoutLayers();
     return result;
   }
@@ -519,11 +516,8 @@ public abstract class ElementBuilder {
    * @return the Element created
    */
   @Nonnull
-  public Element build(
-      @Nonnull final Nifty nifty,
-      @Nonnull final Screen screen,
-      @Nonnull final Element parent,
-      @Nullable final Element before) {
+  public Element build(@Nonnull final Element parent, @Nullable final Element before) {
+    Screen screen = parent.getScreen();
     List<Element> parentList = parent.getChildren();
     int index = parentList.size();
     for (int i = 0; i < parentList.size(); i++) {
@@ -533,9 +527,49 @@ public abstract class ElementBuilder {
       }
     }
     ElementType type = buildElementType();
-    Element result = nifty.createElementFromType(screen, parent, type, index);
+    Element result = parent.getNifty().createElementFromType(screen, parent, type, index);
     screen.layoutLayers();
     return result;
+  }
+
+  /**
+   * Build a element
+   *
+   * @return the element created
+   */
+  @Deprecated
+  public Element build(@Nonnull final Nifty nifty, @Nonnull final Screen screen, @Nonnull final Element parent) {
+    return build(parent);
+  }
+
+  /**
+   * Build an element in a specified position in parent element list
+   *
+   * @return the Element created
+   */
+  @Deprecated
+  @Nonnull
+  public Element build(
+      @Nonnull final Nifty nifty,
+      @Nonnull final Screen screen,
+      @Nonnull final Element parent,
+      final int index) {
+    return build(parent, index);
+  }
+
+  /**
+   * Build an element after a element in parent children list
+   *
+   * @return the Element created
+   */
+  @Deprecated
+  @Nonnull
+  public Element build(
+      @Nonnull final Nifty nifty,
+      @Nonnull final Screen screen,
+      @Nonnull final Element parent,
+      @Nullable final Element before) {
+    return build(parent, before);
   }
 
   /**

--- a/nifty-core/src/main/java/de/lessvoid/nifty/elements/Element.java
+++ b/nifty-core/src/main/java/de/lessvoid/nifty/elements/Element.java
@@ -2618,6 +2618,11 @@ public class Element implements NiftyEvent, EffectManager.Notify {
     return nifty;
   }
 
+  @Nullable
+  public Screen getScreen() {
+	return screen;
+  }
+
   @Nonnull
   public <T extends EffectImpl> List<Effect> getEffects(
       @Nonnull final EffectEventId effectEventId,


### PR DESCRIPTION
`Element` objects already hold `Nifty` and `Screen` instances, so we can use them when building new elements which would result in simpler API for the Nifty user.

@void256 @bgroenks96 Although I am not using most of the default controls, I can do the refactoring proposed in #41. That is to return `this` instance in setter methods for stacking (without event functions such as `onClick`, etc.). I remember this was the thing which discouraged me from using Nifty when I first started. Shall I do the refactoring?