### PR TITLE
Fixed build() methods in builders extending ElementBuilder.

### DIFF
--- a/nifty-core/src/main/java/de/lessvoid/nifty/builder/ElementBuilder.java
+++ b/nifty-core/src/main/java/de/lessvoid/nifty/builder/ElementBuilder.java
@@ -586,7 +586,7 @@ public abstract class ElementBuilder {
    */
   @Nonnull
   public Element build(@Nonnull final Element parent, @Nullable final Element before) {
-    Screen screen = parent.getScreen();
+    //find the index of 'before' element
     List<Element> parentList = parent.getChildren();
     int index = parentList.size();
     for (int i = 0; i < parentList.size(); i++) {
@@ -595,10 +595,8 @@ public abstract class ElementBuilder {
         break;
       }
     }
-    ElementType type = buildElementType();
-    Element result = parent.getNifty().createElementFromType(screen, parent, type, index);
-    screen.layoutLayers();
-    return result;
+
+    return this.build(parent, index);
   }
 
   /**

--- a/nifty-core/src/main/java/de/lessvoid/nifty/builder/LayerBuilder.java
+++ b/nifty-core/src/main/java/de/lessvoid/nifty/builder/LayerBuilder.java
@@ -1,6 +1,5 @@
 package de.lessvoid.nifty.builder;
 
-import de.lessvoid.nifty.Nifty;
 import de.lessvoid.nifty.controls.dynamic.LayerCreator;
 import de.lessvoid.nifty.elements.Element;
 import de.lessvoid.nifty.screen.Screen;
@@ -19,8 +18,18 @@ public class LayerBuilder extends ElementBuilder {
   }
 
   @Override
-  public Element build(@Nonnull final Nifty nifty, @Nonnull final Screen screen, @Nonnull final Element parent) {
-    Element e = super.build(nifty, screen, parent);
+  public Element build(@Nonnull final Element parent) {
+    Element e = super.build(parent);
+    Screen screen = parent.getScreen();
+    screen.addLayerElement(e);
+    screen.processAddAndRemoveLayerElements();
+    return e;
+  }
+
+  @Override
+  public Element build(@Nonnull final Element parent, final int index) {
+    Element e = super.build(parent, index);
+    Screen screen = parent.getScreen();
     screen.addLayerElement(e);
     screen.processAddAndRemoveLayerElements();
     return e;

--- a/nifty-core/src/main/java/de/lessvoid/nifty/builder/PopupBuilder.java
+++ b/nifty-core/src/main/java/de/lessvoid/nifty/builder/PopupBuilder.java
@@ -4,7 +4,6 @@ import de.lessvoid.nifty.Nifty;
 import de.lessvoid.nifty.controls.dynamic.PopupCreator;
 import de.lessvoid.nifty.elements.Element;
 import de.lessvoid.nifty.loaderv2.types.PopupType;
-import de.lessvoid.nifty.screen.Screen;
 
 import javax.annotation.Nonnull;
 
@@ -21,7 +20,13 @@ public class PopupBuilder extends ElementBuilder {
 
   @Override
   @Nonnull
-  public Element build(@Nonnull final Nifty nifty, @Nonnull final Screen screen, @Nonnull final Element parent) {
+  public Element build(@Nonnull final Element parent) {
+    throw new RuntimeException("you can't build popups using the PopupBuilder. Please call register() instead to " +
+        "dynamically register popups with Nifty.");
+  }
+
+  @Override
+  public Element build(@Nonnull final Element parent, final int index) {
     throw new RuntimeException("you can't build popups using the PopupBuilder. Please call register() instead to " +
         "dynamically register popups with Nifty.");
   }

--- a/nifty-core/src/main/java/de/lessvoid/nifty/screen/Screen.java
+++ b/nifty-core/src/main/java/de/lessvoid/nifty/screen/Screen.java
@@ -653,6 +653,7 @@ public class Screen {
   @SuppressWarnings("NullableProblems")
   public void setRootElement(@Nonnull final Element rootElementParam) {
     rootElement = rootElementParam;
+    rootElement.bindControls(this);
   }
 
   /**


### PR DESCRIPTION
When I submitted PR #456, I didn't consider that other builders may be overriding `build()` methods. It is now fixed.

//EDIT: There seem to be some issues with this PR, I am investigating that.