### PR TITLE
introduces minimum size value

### DIFF
--- a/nifty-core/src/main/java/de/lessvoid/nifty/elements/Element.java
+++ b/nifty-core/src/main/java/de/lessvoid/nifty/elements/Element.java
@@ -769,7 +769,7 @@ public class Element implements NiftyEvent, EffectManager.Notify {
 
     if (layoutManager != null) {
 
-      // unset width, or width="sum" or width="max"
+      // unset width, or width="sum", width="max" or width="min"
       // try to calculate the width constraint using the children
       // but only if all child elements have a fixed pixel width.
 
@@ -824,6 +824,19 @@ public class Element implements NiftyEvent, EffectManager.Notify {
           setConstraintWidth(SizeValue.max(0));
         }
 
+      } else if (myWidth.hasMin()) {
+        List<LayoutPart> layoutPartChild = getLayoutChildrenWithIndependentWidth();
+        SizeValue newWidth = layoutPart.getMinWidth(layoutPartChild);
+        if (newWidth.hasValue()) {
+          int newWidthPx = newWidth.getValueAsInt(0);
+          newWidthPx += this.layoutPart.getBoxConstraints().getPaddingLeft().getValueAsInt(newWidth.getValueAsInt
+                  (newWidthPx));
+          newWidthPx += this.layoutPart.getBoxConstraints().getPaddingRight().getValueAsInt(newWidth.getValueAsInt
+                  (newWidthPx));
+          setConstraintWidth(SizeValue.min(newWidthPx));
+        } else {
+          setConstraintWidth(SizeValue.min(0));
+        }
       }
     }
   }
@@ -863,7 +876,7 @@ public class Element implements NiftyEvent, EffectManager.Notify {
 
     if (layoutManager != null) {
 
-      // unset height, or height="sum" or height="max"
+      // unset height, or height="sum", height="max" or height="min"
       // try to calculate the height constraint using the children
       // but only if all child elements have a fixed pixel height.
 
@@ -919,6 +932,19 @@ public class Element implements NiftyEvent, EffectManager.Notify {
           setConstraintHeight(SizeValue.max(0));
         }
 
+      } else if (myHeight.hasMin()) {
+        List<LayoutPart> layoutPartChild = getLayoutChildrenWithIndependentHeight();
+        SizeValue newHeight = layoutPart.getMinHeight(layoutPartChild);
+        if (newHeight.hasValue()) {
+          int newHeightPx = newHeight.getValueAsInt(0);
+          newHeightPx += this.layoutPart.getBoxConstraints().getPaddingTop().getValueAsInt(newHeight.getValueAsInt
+                  (newHeightPx));
+          newHeightPx += this.layoutPart.getBoxConstraints().getPaddingBottom().getValueAsInt(newHeight.getValueAsInt
+                  (newHeightPx));
+          setConstraintHeight(SizeValue.min(newHeightPx));
+        } else {
+          setConstraintHeight(SizeValue.min(0));
+        }
       }
     }
   }

--- a/nifty-core/src/main/java/de/lessvoid/nifty/layout/LayoutPart.java
+++ b/nifty-core/src/main/java/de/lessvoid/nifty/layout/LayoutPart.java
@@ -103,6 +103,30 @@ public class LayoutPart {
   }
 
   /**
+   * Calculates the minimum width of the given child elements. This takes padding of this LayoutPart
+   * as well as the margin values of the child elements into account.
+   *
+   * @param children List<LayoutPart> to calculate min width
+   * @return min width
+   */
+  @Nonnull
+  public SizeValue getMinWidth(@Nonnull final List<LayoutPart> children) {
+    if (children.isEmpty()) {
+      return SizeValue.px(0);
+    }
+    int newWidth = Integer.MAX_VALUE;
+    for (LayoutPart e : children) {
+      int partWidth = e.getBoxConstraints().getWidth().getValueAsInt(0);
+      partWidth += e.getBoxConstraints().getMarginLeft().getValueAsInt(0);
+      partWidth += e.getBoxConstraints().getMarginRight().getValueAsInt(0);
+      if (partWidth < newWidth) {
+        newWidth = partWidth;
+      }
+    }
+    return SizeValue.px(newWidth);
+  }
+
+  /**
    * Calculates the maximum height of the given child elements. This takes padding of this LayoutPart
    * as well as the margin values of the child elements into account.
    *
@@ -117,6 +141,30 @@ public class LayoutPart {
       partHeight += e.getBoxConstraints().getMarginTop().getValueAsInt(0);
       partHeight += e.getBoxConstraints().getMarginBottom().getValueAsInt(0);
       if (partHeight > newHeight) {
+        newHeight = partHeight;
+      }
+    }
+    return SizeValue.px(newHeight);
+  }
+
+  /**
+   * Calculates the minimum height of the given child elements. This takes padding of this LayoutPart
+   * as well as the margin values of the child elements into account.
+   *
+   * @param children List<LayoutPart> to calculate min height
+   * @return min height
+   */
+  @Nonnull
+  public SizeValue getMinHeight(@Nonnull final List<LayoutPart> children) {
+    if (children.isEmpty()) {
+      return SizeValue.px(0);
+    }
+    int newHeight = Integer.MAX_VALUE;
+    for (LayoutPart e : children) {
+      int partHeight = e.getBoxConstraints().getHeight().getValueAsInt(0);
+      partHeight += e.getBoxConstraints().getMarginTop().getValueAsInt(0);
+      partHeight += e.getBoxConstraints().getMarginBottom().getValueAsInt(0);
+      if (partHeight < newHeight) {
         newHeight = partHeight;
       }
     }

--- a/nifty-core/src/main/java/de/lessvoid/nifty/tools/SizeValue.java
+++ b/nifty-core/src/main/java/de/lessvoid/nifty/tools/SizeValue.java
@@ -33,6 +33,12 @@ public final class SizeValue {
   private static final SizeValue MAX = new SizeValue(SizeValueType.Maximum);
 
   /**
+   * The shared instance of a minimum size value.
+   */
+  @Nonnull
+  private static final SizeValue MIN = new SizeValue(SizeValueType.Minimum);
+
+  /**
    * The shared instance of the 0px size value. This is used to extremely often that it comes in handy to share the
    * instance for some minor optimization.
    */
@@ -348,6 +354,17 @@ public final class SizeValue {
   }
 
   /**
+   * Get a minimum size value.
+   *
+   * @return the size value instance representing the minimum value
+   * @see de.lessvoid.nifty.tools.SizeValueType#Minimum
+   */
+  @Nonnull
+  public static SizeValue min() {
+    return MIN;
+  }
+
+  /**
    * Create a maximum size value that stores a computed value.
    *
    * @param computedValue the computed size
@@ -357,6 +374,18 @@ public final class SizeValue {
   @Nonnull
   public static SizeValue max(final int computedValue) {
     return new SizeValue(SizeValueType.Maximum, computedValue);
+  }
+
+  /**
+   * Create a minimum size value that stores a computed value.
+   *
+   * @param computedValue the computed size
+   * @return the size value instance representing the minimum with computed size
+   * @see de.lessvoid.nifty.tools.SizeValueType#Minimum
+   */
+  @Nonnull
+  public static SizeValue min(final int computedValue) {
+    return new SizeValue(SizeValueType.Minimum, computedValue);
   }
 
   /**
@@ -511,6 +540,10 @@ public final class SizeValue {
 
   public boolean hasMax() {
     return type == SizeValueType.Maximum;
+  }
+
+  public boolean hasMin() {
+    return type == SizeValueType.Minimum;
   }
 
   @Override

--- a/nifty-core/src/main/java/de/lessvoid/nifty/tools/SizeValueType.java
+++ b/nifty-core/src/main/java/de/lessvoid/nifty/tools/SizeValueType.java
@@ -23,24 +23,35 @@ public enum SizeValueType {
   /**
    * The sum size type.
    * <p/>
-   * When set, this size value will be the sum of the sizes of the content/children  of the element it is used on.
-   * Only children with absolute size values will be considered, or children that also have a sum/max size value.
+   * When set, this size value will be the sum of the sizes of the content/children of the element it is used on.
+   * Only children with absolute size values will be considered, or children that also have a sum/max/min size value.
    * <p/>
    * Builders or XML should use the value "s" or "sum". A pixel value can also be given in the form of "100s",
-   * but this is for internal use (it represents the calculated width).
+   * but this is for internal use (it represents the calculated size).
    */
   Sum("s", true, ValueRequirement.CalculatedOnly),
 
   /**
    * The maximum size type.
    * <p/>
-   * When set, this size value will be the highest of the sizes of the content/children  of the element it is used on.
-   * Only children with absolute size values will be considered, or children that also have a sum/max size value.
+   * When set, this size value will be the highest of the sizes of the content/children of the element it is used on.
+   * Only children with absolute size values will be considered, or children that also have a sum/max/min size value.
    * <p/>
    * Builders or XML should use the value "m" or "max". A pixel value can also be given in the form of "100m",
-   * but this is for internal use (it represents the calculated width).
+   * but this is for internal use (it represents the calculated size).
    */
   Maximum("m", true, ValueRequirement.CalculatedOnly),
+
+  /**
+   * The minimum size type.
+   * <p/>
+   * When set, this size value will be the lowest of the sizes of the content/children of the element it is used on.
+   * Only children with absolute size values will be considered, or children that also have a sum/max/min size value.
+   * <p/>
+   * Builders or XML should use the value "min". A pixel value can also be given in the form of "100min",
+   * but this is for internal use (it represents the calculated size).
+   */
+  Minimum("min", true, ValueRequirement.CalculatedOnly),
 
   /**
    * The percent value type. This will resolve to a percentage of the parents size.


### PR DESCRIPTION
Hey guys,
I had the need for a new size value that sets the size of an element to the minimum size of all children. While I understand that this makes not too much sense while looking at average use cases (why would someone make a container not big enough to hold all children), I don´t think it would do any harm to add it. For example see the following example where the texts overlap, but only one text is visible at a time: 
```xml
<panel childLayout="horizontal">
	<panel childLayout="vertical" width="min">
		<text text="Menu1" font="aurulent-sans-16.fnt"/>
		<text text="LongerTextThatIsNotAlwaysVisible" font="aurulent-sans-16.fnt" visible="false"/>
	</panel>
	<panel childLayout="vertical" width="min">
		<text text="Menu2" font="aurulent-sans-16.fnt"/>
		<text text="LongerTextThatIsNotAlwaysVisible" font="aurulent-sans-16.fnt" visible="false"/>
	</panel>
</panel>
```
Is there any other way of achieving the same structure ("Menu1" and "Menu" next to each other, the longer texts beneath each menu entries) without using absolute values?