### PR TITLE
Disable double click in slider control

### DIFF
--- a/nifty-controls/src/main/resources/nifty-controls/nifty-slider.xml
+++ b/nifty-controls/src/main/resources/nifty-controls/nifty-slider.xml
@@ -6,7 +6,7 @@
         <panel style="#panel" focusable="true">
             <interact onMouseWheel="mouseWheel()"/>
             <image style="#up">
-                <interact onClickRepeat="upClick()"/>
+                <interact onMultiClick="upClick()" onClickRepeat="upClick()"/>
             </image>
             <image id="#background" style="#background">
                 <interact onClick="mouseClick()" onClickMouseMove="mouseClick()"/>
@@ -15,7 +15,7 @@
                 </image>
             </image>
             <image style="#down">
-                <interact onClickRepeat="downClick()"/>
+                <interact onMultiClick="downClick()" onClickRepeat="downClick()"/>
             </image>
         </panel>
     </controlDefinition>
@@ -26,7 +26,7 @@
         <panel style="#panel">
             <interact onMouseWheel="mouseWheel()"/>
             <image style="#left">
-                <interact onClickRepeat="upClick()"/>
+                <interact onMultiClick="upClick()" onClickRepeat="upClick()"/>
             </image>
             <image id="#background" style="#background">
                 <interact onClick="mouseClick()" onClickMouseMove="mouseClick()"/>
@@ -35,7 +35,7 @@
                 </image>
             </image>
             <image style="#right">
-                <interact onClickRepeat="downClick()"/>
+                <interact onMultiClick="downClick()" onClickRepeat="downClick()"/>
             </image>
         </panel>
     </controlDefinition>


### PR DESCRIPTION
Double clicking on a slider just swallows the click because it is a multiclick event now and the slider is only listening for single clicks. This should make clicks, multiclicks and click holding do the same. I don't know if there are other controls that would benefit of something like this, but in my case, this was driving me crazy.