### PR TITLE
Exclude jnlp-api (javaws) from slick2d dependencies for compiling on …

### DIFF
--- a/nifty-renderer-slick2d/pom.xml
+++ b/nifty-renderer-slick2d/pom.xml
@@ -35,6 +35,12 @@
             <groupId>org.slick2d</groupId>
             <artifactId>slick2d-core</artifactId>
             <version>1.0.1</version>
+	    <exclusions>
+              <exclusion>
+		<groupId>javax.jnlp</groupId>
+		<artifactId>jnlp-api</artifactId>
+              </exclusion>
+	    </exclusions>
         </dependency>
         <dependency>
             <groupId>org.lwjgl.lwjgl</groupId>

--- a/nifty-soundsystem-openal/pom.xml
+++ b/nifty-soundsystem-openal/pom.xml
@@ -12,6 +12,12 @@
             <groupId>org.slick2d</groupId>
             <artifactId>slick2d-core</artifactId>
             <version>1.0.1</version>
+	    <exclusions>
+              <exclusion>
+		<groupId>javax.jnlp</groupId>
+		<artifactId>jnlp-api</artifactId>
+              </exclusion>
+	    </exclusions>
         </dependency>
         <dependency>
             <groupId>com.github.nifty-gui</groupId>


### PR DESCRIPTION
…JDK 11+

Builds of the 1.4 branch (as of 2021-08-25, commit of 2019-05-25) fail with at least OpenJDK Temurin-11 (and probably any default installation of JDK11, including Oracle):

```
[ERROR] Failed to execute goal on project nifty-slick2d-renderer: Could not resolve dependencies for project com.github.nifty-gui:nifty-slick2d-renderer:jar:1.4.4-SNAPSHOT: Could not find artifact javax.jnlp:jnlp-api:jar:5.0 at specified path /opt/jdk-11.0.12+7/lib/javaws.jar
[ERROR] Failed to execute goal on project nifty-openal-soundsystem: Could not resolve dependencies for project com.github.nifty-gui:nifty-openal-soundsystem:jar:1.4.4-SNAPSHOT: Could not find artifact javax.jnlp:jnlp-api:jar:5.0 at specified path /opt/jdk-11.0.12+7/lib/javaws.jar
```
JavaWebStart (Oracle JNLP implementation) and the JNLP API itself have been deprecated by Oracle since Java 9, and removed in Java 11.

This is a proposal for fixing the build in a minimal way by excluding JNLP from Slick2D dependencies in `nifty-renderer-slick2d` and `nifty-soundsystem-openal` `pom.xml` files.
