### PR TITLE
Ducos 1.5

### DIFF
--- a/nifty-core/src/main/java/de/lessvoid/nifty/loaderv2/types/ElementType.java
+++ b/nifty-core/src/main/java/de/lessvoid/nifty/loaderv2/types/ElementType.java
@@ -8,7 +8,6 @@ import de.lessvoid.nifty.controls.dynamic.attributes.ControlAttributes;
 import de.lessvoid.nifty.elements.Element;
 import de.lessvoid.nifty.elements.render.ElementRenderer;
 import de.lessvoid.nifty.input.NiftyInputMapping;
-import de.lessvoid.nifty.input.mapping.DefaultInputMapping;
 import de.lessvoid.nifty.layout.LayoutPart;
 import de.lessvoid.nifty.loaderv2.types.helper.CollectionLogger;
 import de.lessvoid.nifty.loaderv2.types.helper.ElementRendererCreator;
@@ -361,7 +360,7 @@ public class ElementType extends XmlBaseType {
     getAttributes().resolveParameters(parentAttributes);
 
     Attributes newParent = new Attributes(parentAttributes);
-    newParent.merge(getAttributes());
+    newParent.mergeAndOverride(getAttributes());
 
     interact.resolveParameters(newParent);
     effects.resolveParameters(newParent);

--- a/nifty-core/src/main/java/de/lessvoid/xml/xpp3/Attributes.java
+++ b/nifty-core/src/main/java/de/lessvoid/xml/xpp3/Attributes.java
@@ -256,13 +256,18 @@ public class Attributes {
   }
 
   public void merge(@Nonnull final Attributes src) {
-    Map<String, String> srcAttributes = src.attributes;
+    merge(src, false);
+  }
 
-    for (Map.Entry<String, String> srcAttribute : srcAttributes.entrySet()) {
+  public void mergeAndOverride(@Nonnull final Attributes src) {
+    merge(src, true);
+  }
+
+  private void merge(@Nonnull final Attributes src, boolean override) {
+    for (Map.Entry<String, String> srcAttribute : src.attributes.entrySet()) {
       String srcKey = srcAttribute.getKey();
-      if (!attributes.containsKey(srcKey)) {
+      if (override || !attributes.containsKey(srcKey)) {
         attributes.put(srcKey, srcAttribute.getValue());
-
         for (Map.Entry<String, Set<String>> tag : src.taggedAttributes.entrySet()) {
           if (tag.getValue().contains(srcKey)) {
             Set<String> attribForTag = taggedAttributes.get(tag.getKey());

--- a/nifty-renderer-slick2d/pom.xml
+++ b/nifty-renderer-slick2d/pom.xml
@@ -35,6 +35,12 @@
             <groupId>org.slick2d</groupId>
             <artifactId>slick2d-core</artifactId>
             <version>1.0.1</version>
+	    <exclusions>
+              <exclusion>
+		<groupId>javax.jnlp</groupId>
+		<artifactId>jnlp-api</artifactId>
+              </exclusion>
+	    </exclusions>
         </dependency>
         <dependency>
             <groupId>org.lwjgl.lwjgl</groupId>

--- a/nifty-soundsystem-openal/pom.xml
+++ b/nifty-soundsystem-openal/pom.xml
@@ -12,6 +12,12 @@
             <groupId>org.slick2d</groupId>
             <artifactId>slick2d-core</artifactId>
             <version>1.0.1</version>
+	    <exclusions>
+              <exclusion>
+		<groupId>javax.jnlp</groupId>
+		<artifactId>jnlp-api</artifactId>
+              </exclusion>
+	    </exclusions>
         </dependency>
         <dependency>
             <groupId>com.github.nifty-gui</groupId>


### PR DESCRIPTION
   Partial merge of branch 1.4 into 1.5
    
  This commit is a first step in the effort of merging branch 1.4
  into 1.5
    
  The slick2d and openal modules were disabled in 1.5 because of
  dependencies on javaws, unavailable in jdk-11 (compatibility target
  of branch 1.5), preventing builds of the project with jdk-11.
    
  They have been reenabled in the main pom.xml of 1.5
  since 1.4 can now be built with jdk-11 with exclusion rules on javaws in
  second-level pom.xml files (introduced in pull request #488 of 1.4)
    
  A merge of the updated 1.4 branch has been performed into 1.5 but has
  led to conflicting updates in one file:
    
  `nifty-core/src/test/java/de/lessvoid/nifty/loaderv2/NiftyLoaderTest.java`
    
  Since modifications in this file were significant in both branches since
  their divergence, it has been decided in this commit to leave the file
  in its former state in branch 1.5, in order to minimize changes in this
  branch.
    
  Maintainers of `loaderv2/NiftyLoaderTest.java` in branches 1.4 and 1.5
  are welcome to check last updates of this file in order to complete
  merges of both branches.